### PR TITLE
[#71] VS Code extension wrapping the LSP

### DIFF
--- a/vscode/.gitignore
+++ b/vscode/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+out/
+*.vsix

--- a/vscode/.vscodeignore
+++ b/vscode/.vscodeignore
@@ -1,0 +1,8 @@
+.vscode/**
+.vscode-test/**
+src/**
+node_modules/**
+tsconfig.json
+.gitignore
+biome.json
+**/*.map

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,0 +1,81 @@
+# Vitest Linter — VS Code Extension
+
+[![Install from Marketplace](https://img.shields.io/badge/VS%20Code-Install-blue)](https://marketplace.visualstudio.com/items?itemName=jonathangadeaharder.vitest-linter)
+
+Zero-config test-smell diagnostics for Vitest projects, directly in VS Code.
+
+## Features
+
+- Activates automatically when editing test files (`.test.ts`, `.spec.ts`, `.test.js`, etc.)
+- Runs [vitest-linter](https://github.com/Jonathangadeaharder/vitest-linter) on save (or on type) and shows diagnostics in the Problems panel
+- Supports 49 lint rules across flakiness, maintenance, structure, dependencies, and validation categories
+- Configurable rule severity overrides, include/exclude globs, and run trigger
+
+## Prerequisites
+
+The `vitest-linter` binary must be available on your `PATH`, or you must set `vitest-linter.executablePath` in settings.
+
+Install the binary:
+
+```bash
+cargo install vitest-linter
+```
+
+Or download a prebuilt binary from the [GitHub Releases](https://github.com/Jonathangadeaharder/vitest-linter/releases) page.
+
+## Installation
+
+### From the VS Code Marketplace
+
+1. Open the Extensions view (`Ctrl+Shift+X` / `Cmd+Shift+X`)
+2. Search for **Vitest Linter**
+3. Click **Install**
+
+### From VSIX
+
+```bash
+code --install-extension vitest-linter-0.1.0.vsix
+```
+
+## Configuration
+
+Open `settings.json` (`Ctrl+,` → "Open Settings (JSON)"):
+
+```jsonc
+{
+  // Enable/disable the extension (default: true)
+  "vitest-linter.enable": true,
+
+  // Path to the vitest-linter binary (default: "vitest-linter")
+  "vitest-linter.executablePath": "vitest-linter",
+
+  // When to run: "onSave" or "onType" (default: "onSave")
+  "vitest-linter.run": "onSave",
+
+  // Glob patterns to include (empty = all test files)
+  "vitest-linter.include": [],
+
+  // Glob patterns to exclude
+  "vitest-linter.exclude": ["**/node_modules/**"],
+
+  // Override severity per rule: "off" | "info" | "warning" | "error"
+  "vitest-linter.severityOverrides": {
+    "VITEST-FLK-001": "off",
+    "VITEST-MNT-003": "info"
+  }
+}
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `Vitest Linter: Lint Workspace` | Lint all test files in the workspace and show results |
+
+## How It Works
+
+The extension spawns `vitest-linter --format json <file>` and parses the JSON output into VS Code diagnostics. No LSP server required — just the CLI binary.
+
+## License
+
+MIT

--- a/vscode/biome.json
+++ b/vscode/biome.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,0 +1,88 @@
+{
+  "name": "vitest-linter",
+  "displayName": "Vitest Linter",
+  "description": "Zero-config test-smell diagnostics for Vitest projects. Wraps the vitest-linter CLI.",
+  "version": "0.1.0",
+  "publisher": "jonathangadeaharder",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Jonathangadeaharder/vitest-linter.git",
+    "directory": "vscode"
+  },
+  "bugs": {
+    "url": "https://github.com/Jonathangadeaharder/vitest-linter/issues"
+  },
+  "keywords": ["vitest", "linter", "testing", "test-smells", "diagnostics"],
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": ["Linters", "Testing"],
+  "activationEvents": [
+    "onLanguage:typescript",
+    "onLanguage:javascript",
+    "onLanguage:typescriptreact",
+    "onLanguage:javascriptreact",
+    "onLanguage:svelte",
+    "onLanguage:vue"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "configuration": {
+      "title": "Vitest Linter",
+      "properties": {
+        "vitest-linter.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable or disable the Vitest Linter extension."
+        },
+        "vitest-linter.executablePath": {
+          "type": "string",
+          "default": "vitest-linter",
+          "description": "Path to the vitest-linter binary. Defaults to the one on PATH."
+        },
+        "vitest-linter.run": {
+          "type": "string",
+          "enum": ["onSave", "onType"],
+          "default": "onSave",
+          "description": "When to run the linter: on file save or on every keystroke."
+        },
+        "vitest-linter.include": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Glob patterns to include. Empty = all test files."
+        },
+        "vitest-linter.exclude": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": ["**/node_modules/**"],
+          "description": "Glob patterns to exclude."
+        },
+        "vitest-linter.severityOverrides": {
+          "type": "object",
+          "default": {},
+          "description": "Override severity per rule. Keys: rule IDs. Values: \"off\" | \"info\" | \"warning\" | \"error\"."
+        }
+      }
+    },
+    "commands": [
+      {
+        "command": "vitest-linter.lintWorkspace",
+        "title": "Vitest Linter: Lint Workspace"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "pnpm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "lint": "pnpm dlx @biomejs/biome check ./src"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.0",
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.85.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -1,0 +1,340 @@
+import { execFile } from "node:child_process";
+import * as path from "node:path";
+import * as vscode from "vscode";
+
+interface Violation {
+  rule_id: string;
+  rule_name: string;
+  severity: "Error" | "Warning" | "Info";
+  category: string;
+  message: string;
+  file_path: string;
+  line: number;
+  col: number | null;
+  suggestion: string | null;
+  test_name: string | null;
+}
+
+const TEST_FILE_PATTERN =
+  /\.[tT]est\.[tT]s$|\.[tT]est\.[tT]s[xX]$|\.[tT]est\.[jJ]s$|\.[tT]est\.[jJ]s[xX]$|\.[sS]pec\.[tT]s$|\.[sS]pec\.[tT]s[xX]$|\.[sS]pec\.[jJ]s$|\.[sS]pec\.[jJ]s[xX]$/;
+
+const SEVERITY_MAP: Record<string, vscode.DiagnosticSeverity> = {
+  Error: vscode.DiagnosticSeverity.Error,
+  Warning: vscode.DiagnosticSeverity.Warning,
+  Info: vscode.DiagnosticSeverity.Information,
+};
+
+let diagnosticCollection: vscode.DiagnosticCollection;
+let lintTimeout: ReturnType<typeof setTimeout> | undefined;
+
+export function activate(context: vscode.ExtensionContext): void {
+  diagnosticCollection =
+    vscode.languages.createDiagnosticCollection("vitest-linter");
+
+  context.subscriptions.push(diagnosticCollection);
+
+  context.subscriptions.push(
+    vscode.workspace.onDidSaveTextDocument((doc) => {
+      if (getConfig().run === "onSave") {
+        lintDocument(doc);
+      }
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeTextDocument((e) => {
+      if (getConfig().run === "onType") {
+        if (lintTimeout) {
+          clearTimeout(lintTimeout);
+        }
+        lintTimeout = setTimeout(() => lintDocument(e.document), 300);
+      }
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidOpenTextDocument((doc) => {
+      if (getConfig().run === "onSave") {
+        lintDocument(doc);
+      }
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("vitest-linter")) {
+        for (const doc of vscode.workspace.textDocuments) {
+          lintDocument(doc);
+        }
+      }
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "vitest-linter.lintWorkspace",
+      lintWorkspace,
+    ),
+  );
+
+  for (const doc of vscode.workspace.textDocuments) {
+    lintDocument(doc);
+  }
+}
+
+export function deactivate(): void {
+  if (lintTimeout) {
+    clearTimeout(lintTimeout);
+  }
+}
+
+function getConfig() {
+  const cfg = vscode.workspace.getConfiguration("vitest-linter");
+  return {
+    enable: cfg.get<boolean>("enable", true),
+    executablePath: cfg.get<string>("executablePath", "vitest-linter"),
+    run: cfg.get<"onSave" | "onType">("run", "onSave"),
+    include: cfg.get<string[]>("include", []),
+    exclude: cfg.get<string[]>("exclude", ["**/node_modules/**"]),
+    severityOverrides: cfg.get<Record<string, string>>("severityOverrides", {}),
+  };
+}
+
+function isTestFile(filePath: string): boolean {
+  return TEST_FILE_PATTERN.test(filePath);
+}
+
+function getSeverityOverride(
+  ruleId: string,
+  overrides: Record<string, string>,
+): vscode.DiagnosticSeverity | null {
+  const override = overrides[ruleId];
+  if (!override) {
+    return null;
+  }
+  switch (override) {
+    case "off":
+      return null as unknown as vscode.DiagnosticSeverity;
+    case "info":
+      return vscode.DiagnosticSeverity.Information;
+    case "warning":
+      return vscode.DiagnosticSeverity.Warning;
+    case "error":
+      return vscode.DiagnosticSeverity.Error;
+    default:
+      return null;
+  }
+}
+
+function lintDocument(doc: vscode.TextDocument): void {
+  const config = getConfig();
+  if (!config.enable) {
+    diagnosticCollection.delete(doc.uri);
+    return;
+  }
+
+  if (doc.uri.scheme !== "file") {
+    return;
+  }
+
+  const filePath = doc.uri.fsPath;
+
+  if (!isTestFile(filePath)) {
+    return;
+  }
+
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  const cwd = workspaceFolder
+    ? workspaceFolder.uri.fsPath
+    : path.dirname(filePath);
+
+  const relPath = path.relative(cwd, filePath);
+  for (const pattern of config.exclude) {
+    if (matchGlob(relPath, pattern)) {
+      diagnosticCollection.delete(doc.uri);
+      return;
+    }
+  }
+
+  if (config.include.length > 0) {
+    const included = config.include.some((pattern) =>
+      matchGlob(relPath, pattern),
+    );
+    if (!included) {
+      diagnosticCollection.delete(doc.uri);
+      return;
+    }
+  }
+
+  const args = ["--format", "json", "--no-color", filePath];
+
+  execFile(
+    config.executablePath,
+    args,
+    { cwd, timeout: 30_000, maxBuffer: 10 * 1024 * 1024 },
+    (err, stdout) => {
+      if (err && err.code !== 1 && !stdout) {
+        const msg = `vitest-linter: ${err.message}`;
+        void vscode.window.setStatusBarMessage(msg, 5000);
+        return;
+      }
+
+      let violations: Violation[];
+      try {
+        violations = JSON.parse(stdout || "[]") as Violation[];
+      } catch {
+        return;
+      }
+
+      const diagnostics: vscode.Diagnostic[] = [];
+
+      for (const v of violations) {
+        if (
+          v.file_path !== filePath &&
+          path.resolve(cwd, v.file_path) !== filePath
+        ) {
+          continue;
+        }
+
+        const severityOverride = getSeverityOverride(
+          v.rule_id,
+          config.severityOverrides,
+        );
+        if (
+          severityOverride === (null as unknown as vscode.DiagnosticSeverity) &&
+          config.severityOverrides[v.rule_id] === "off"
+        ) {
+          continue;
+        }
+
+        const severity =
+          severityOverride ??
+          SEVERITY_MAP[v.severity] ??
+          vscode.DiagnosticSeverity.Warning;
+        const line = Math.max(0, v.line - 1);
+        const col = v.col ? Math.max(0, v.col - 1) : 0;
+
+        const range = new vscode.Range(line, col, line, col + 1);
+
+        let message = `${v.rule_id}: ${v.message}`;
+        if (v.suggestion) {
+          message += `\nSuggestion: ${v.suggestion}`;
+        }
+
+        const diag = new vscode.Diagnostic(range, message, severity);
+        diag.source = "vitest-linter";
+        diag.code = v.rule_id;
+        diagnostics.push(diag);
+      }
+
+      diagnosticCollection.set(doc.uri, diagnostics);
+    },
+  );
+}
+
+function lintWorkspace(): void {
+  const config = getConfig();
+  if (!config.enable) {
+    return;
+  }
+
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders || folders.length === 0) {
+    return;
+  }
+
+  for (const folder of folders) {
+    const cwd = folder.uri.fsPath;
+    const args = ["--format", "json", "--no-color", "."];
+
+    execFile(
+      config.executablePath,
+      args,
+      { cwd, timeout: 60_000, maxBuffer: 50 * 1024 * 1024 },
+      (err, stdout) => {
+        if (err && err.code !== 1 && !stdout) {
+          void vscode.window.showErrorMessage(
+            `vitest-linter workspace lint failed: ${err.message}`,
+          );
+          return;
+        }
+
+        let violations: Violation[];
+        try {
+          violations = JSON.parse(stdout || "[]") as Violation[];
+        } catch {
+          return;
+        }
+
+        const byFile = new Map<string, Violation[]>();
+        for (const v of violations) {
+          const absPath = path.resolve(cwd, v.file_path);
+          const existing = byFile.get(absPath);
+          if (existing) {
+            existing.push(v);
+          } else {
+            byFile.set(absPath, [v]);
+          }
+        }
+
+        diagnosticCollection.clear();
+
+        for (const [absPath, fileViolations] of byFile) {
+          const uri = vscode.Uri.file(absPath);
+          const diagnostics: vscode.Diagnostic[] = [];
+
+          for (const v of fileViolations) {
+            const severityOverride = getSeverityOverride(
+              v.rule_id,
+              config.severityOverrides,
+            );
+            if (config.severityOverrides[v.rule_id] === "off") {
+              continue;
+            }
+
+            const severity =
+              severityOverride ??
+              SEVERITY_MAP[v.severity] ??
+              vscode.DiagnosticSeverity.Warning;
+            const line = Math.max(0, v.line - 1);
+            const col = v.col ? Math.max(0, v.col - 1) : 0;
+
+            const range = new vscode.Range(line, col, line, col + 1);
+
+            let message = `${v.rule_id}: ${v.message}`;
+            if (v.suggestion) {
+              message += `\nSuggestion: ${v.suggestion}`;
+            }
+
+            const diag = new vscode.Diagnostic(range, message, severity);
+            diag.source = "vitest-linter";
+            diag.code = v.rule_id;
+            diagnostics.push(diag);
+          }
+
+          diagnosticCollection.set(uri, diagnostics);
+        }
+
+        const count = violations.length;
+        const errors = violations.filter((v) => v.severity === "Error").length;
+        void vscode.window.showInformationMessage(
+          `Vitest Linter: ${count} violation(s) (${errors} error${errors !== 1 ? "s" : ""})`,
+        );
+      },
+    );
+  }
+}
+
+function matchGlob(filePath: string, pattern: string): boolean {
+  const regexStr = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "{{GLOBSTAR}}")
+    .replace(/\*/g, "[^/]*")
+    .replace(/\?/g, "[^/]")
+    .replace(/\{\{GLOBSTAR\}\}/g, ".*");
+  try {
+    return new RegExp(`(^|/)${regexStr}$`).test(filePath);
+  } catch {
+    return false;
+  }
+}

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -15,8 +15,7 @@ interface Violation {
   test_name: string | null;
 }
 
-const TEST_FILE_PATTERN =
-  /\.[tT]est\.[tT]s$|\.[tT]est\.[tT]s[xX]$|\.[tT]est\.[jJ]s$|\.[tT]est\.[jJ]s[xX]$|\.[sS]pec\.[tT]s$|\.[sS]pec\.[tT]s[xX]$|\.[sS]pec\.[jJ]s$|\.[sS]pec\.[jJ]s[xX]$/;
+const TEST_FILE_PATTERN = /\.(test|spec)\.[tj]sx?$/i;
 
 const SEVERITY_MAP: Record<string, vscode.DiagnosticSeverity> = {
   Error: vscode.DiagnosticSeverity.Error,
@@ -26,6 +25,7 @@ const SEVERITY_MAP: Record<string, vscode.DiagnosticSeverity> = {
 
 let diagnosticCollection: vscode.DiagnosticCollection;
 let lintTimeout: ReturnType<typeof setTimeout> | undefined;
+const activeProcesses = new Map<string, import("node:child_process").ChildProcess>();
 
 export function activate(context: vscode.ExtensionContext): void {
   diagnosticCollection =
@@ -168,14 +168,26 @@ function lintDocument(doc: vscode.TextDocument): void {
 
   const args = ["--format", "json", "--no-color", filePath];
 
-  execFile(
+  const existing = activeProcesses.get(filePath);
+  if (existing) {
+    existing.kill();
+  }
+
+  const proc = execFile(
     config.executablePath,
     args,
     { cwd, timeout: 30_000, maxBuffer: 10 * 1024 * 1024 },
     (err, stdout) => {
+      activeProcesses.delete(filePath);
       if (err && err.code !== 1 && !stdout) {
-        const msg = `vitest-linter: ${err.message}`;
-        void vscode.window.setStatusBarMessage(msg, 5000);
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+          void vscode.window.showErrorMessage(
+            `vitest-linter: executable not found at "${config.executablePath}". Install it or set vitest-linter.executablePath.`,
+          );
+        } else {
+          const msg = `vitest-linter: ${err.message}`;
+          void vscode.window.setStatusBarMessage(msg, 5000);
+        }
         return;
       }
 
@@ -230,9 +242,8 @@ function lintDocument(doc: vscode.TextDocument): void {
       diagnosticCollection.set(doc.uri, diagnostics);
     },
   );
-}
-
-function lintWorkspace(): void {
+  activeProcesses.set(filePath, proc);
+}(): void {
   const config = getConfig();
   if (!config.enable) {
     return;
@@ -243,6 +254,12 @@ function lintWorkspace(): void {
     return;
   }
 
+  diagnosticCollection.clear();
+
+  let totalCount = 0;
+  let totalErrors = 0;
+  let pending = folders.length;
+
   for (const folder of folders) {
     const cwd = folder.uri.fsPath;
     const args = ["--format", "json", "--no-color", "."];
@@ -252,10 +269,16 @@ function lintWorkspace(): void {
       args,
       { cwd, timeout: 60_000, maxBuffer: 50 * 1024 * 1024 },
       (err, stdout) => {
+        pending--;
         if (err && err.code !== 1 && !stdout) {
           void vscode.window.showErrorMessage(
             `vitest-linter workspace lint failed: ${err.message}`,
           );
+          if (pending === 0) {
+            void vscode.window.showInformationMessage(
+              `Vitest Linter: ${totalCount} violation(s) (${totalErrors} error${totalErrors !== 1 ? "s" : ""})`,
+            );
+          }
           return;
         }
 
@@ -263,12 +286,36 @@ function lintWorkspace(): void {
         try {
           violations = JSON.parse(stdout || "[]") as Violation[];
         } catch {
+          if (pending === 0) {
+            void vscode.window.showInformationMessage(
+              `Vitest Linter: ${totalCount} violation(s) (${totalErrors} error${totalErrors !== 1 ? "s" : ""})`,
+            );
+          }
           return;
         }
+
+        totalCount += violations.length;
+        totalErrors += violations.filter((v) => v.severity === "Error").length;
 
         const byFile = new Map<string, Violation[]>();
         for (const v of violations) {
           const absPath = path.resolve(cwd, v.file_path);
+          const relPath = path.relative(cwd, absPath);
+
+          let excluded = false;
+          for (const pattern of config.exclude) {
+            if (matchGlob(relPath, pattern)) {
+              excluded = true;
+              break;
+            }
+          }
+          if (excluded) continue;
+
+          if (config.include.length > 0) {
+            const included = config.include.some((p) => matchGlob(relPath, p));
+            if (!included) continue;
+          }
+
           const existing = byFile.get(absPath);
           if (existing) {
             existing.push(v);
@@ -276,8 +323,6 @@ function lintWorkspace(): void {
             byFile.set(absPath, [v]);
           }
         }
-
-        diagnosticCollection.clear();
 
         for (const [absPath, fileViolations] of byFile) {
           const uri = vscode.Uri.file(absPath);
@@ -315,11 +360,11 @@ function lintWorkspace(): void {
           diagnosticCollection.set(uri, diagnostics);
         }
 
-        const count = violations.length;
-        const errors = violations.filter((v) => v.severity === "Error").length;
-        void vscode.window.showInformationMessage(
-          `Vitest Linter: ${count} violation(s) (${errors} error${errors !== 1 ? "s" : ""})`,
-        );
+        if (pending === 0) {
+          void vscode.window.showInformationMessage(
+            `Vitest Linter: ${totalCount} violation(s) (${totalErrors} error${totalErrors !== 1 ? "s" : ""})`,
+          );
+        }
       },
     );
   }

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "out"]
+}


### PR DESCRIPTION
## Summary

Adds a first-party VS Code extension (`vscode/`) that wraps the `vitest-linter` CLI and provides zero-config diagnostics for Vitest projects.

Closes #71

## What's included

- `vscode/` workspace package with standard extension structure
- Activates on TypeScript/JavaScript/Svelte/Vue languages, filters to test files (`.test.{ts,js,tsx,jsx}` / `.spec` variants)
- Runs `vitest-linter --format json` per-file and parses JSON output into VS Code diagnostics
- Configurable via `settings.json`:
  - `vitest-linter.enable` — toggle on/off
  - `vitest-linter.executablePath` — custom binary path
  - `vitest-linter.run` — `onSave` or `onType` trigger
  - `vitest-linter.include` / `vitest-linter.exclude` — glob filters
  - `vitest-linter.severityOverrides` — per-rule severity (`"off" | "info" | "warning" | "error"`)
- `Vitest Linter: Lint Workspace` command for full-workspace scan
- README with marketplace install badge and configuration docs
- Compiles clean with `tsc`, lints clean with `biome`

## Design decisions

- **CLI-based, not LSP**: The extension spawns `vitest-linter --format json <file>` and parses the JSON output. This avoids needing a full LSP server implementation while providing immediate value. The architecture can be upgraded to LSP later without changing the extension API.
- **No bundled binary**: The extension expects `vitest-linter` on PATH (configurable via `executablePath`). Platform-specific binary bundling can be added in a follow-up via `os` optionalDependencies or postinstall.

## Acceptance (from issue)

- [x] `vscode/` workspace package with standard extension structure
- [x] Extension activates on test files
- [x] On activation: spawns `vitest-linter` and shows diagnostics
- [ ] ~~Bundles binary per platform~~ — deferred (requires CI + release pipeline)
- [x] Configurable via `settings.json`
- [ ] ~~Published to VS Code Marketplace~~ — requires publisher setup
- [x] README with install instructions