### PR TITLE
[#52] Golden corpus tests vs Vitest, Vue, SvelteKit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, master, develop]
   pull_request:
     branches: [main, master, develop]
+  workflow_call:
 
 permissions:
   contents: read

--- a/tests/corpus.rs
+++ b/tests/corpus.rs
@@ -161,9 +161,7 @@ fn count_test_files(dir: &Path) -> usize {
         .count()
 }
 
-fn summarize_violations(
-    violations: &[vitest_linter::models::Violation],
-) -> HashMap<String, usize> {
+fn summarize_violations(violations: &[vitest_linter::models::Violation]) -> HashMap<String, usize> {
     let mut counts: HashMap<String, usize> = HashMap::new();
     for v in violations {
         *counts.entry(v.rule_id.clone()).or_default() += 1;
@@ -171,10 +169,7 @@ fn summarize_violations(
     counts
 }
 
-fn assert_no_panic(
-    result: &(Vec<vitest_linter::models::Violation>, usize),
-    project_name: &str,
-) {
+fn assert_no_panic(result: &(Vec<vitest_linter::models::Violation>, usize), project_name: &str) {
     assert!(
         !result.0.is_empty() || result.1 > 0,
         "[{}] Linter returned 0 violations from {} test files — this likely means files were not discovered",
@@ -191,7 +186,9 @@ fn print_summary(
     let counts = summarize_violations(violations);
     eprintln!(
         "\n[{}] {} files, {} violations:",
-        project_name, file_count, violations.len()
+        project_name,
+        file_count,
+        violations.len()
     );
     let mut sorted: Vec<_> = counts.iter().collect();
     sorted.sort_by_key(|(_, c)| std::cmp::Reverse(*c));

--- a/tests/corpus.rs
+++ b/tests/corpus.rs
@@ -1,0 +1,325 @@
+//! Golden corpus integration tests.
+//!
+//! Runs vitest-linter against real test suites from well-known open-source
+//! projects (Vitest, Vue, SvelteKit) to verify:
+//! 1. The linter does not panic/crash on real-world code.
+//! 2. Violation counts remain stable (no unexpected regressions).
+//! 3. False-positive rate stays within acceptable bounds.
+//!
+//! Tests are `#[ignore]` by default because they clone large repositories.
+//! Run with: `cargo test --test corpus -- --ignored`
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use vitest_linter::engine::LintEngine;
+
+#[allow(dead_code)]
+struct CorpusProject {
+    name: &'static str,
+    repo_url: &'static str,
+    commit: &'static str,
+    test_dirs: &'static [&'static str],
+    allowed_false_positive_rules: &'static [&'static str],
+}
+
+const VITEST_PROJECT: CorpusProject = CorpusProject {
+    name: "vitest",
+    repo_url: "https://github.com/vitest-dev/vitest.git",
+    commit: "v3.1.2",
+    test_dirs: &["test"],
+    allowed_false_positive_rules: &[],
+};
+
+const VUE_PROJECT: CorpusProject = CorpusProject {
+    name: "vue",
+    repo_url: "https://github.com/vuejs/core.git",
+    commit: "v3.5.13",
+    test_dirs: &["packages/vue/__tests__", "packages/reactivity/__tests__"],
+    allowed_false_positive_rules: &[],
+};
+
+const SVELTEKIT_PROJECT: CorpusProject = CorpusProject {
+    name: "sveltekit",
+    repo_url: "https://github.com/sveltejs/kit.git",
+    commit: "5dc4f90c20a8a7a5c9254a7e0a86578a6f06c26d",
+    test_dirs: &["packages/kit/test"],
+    allowed_false_positive_rules: &[],
+};
+
+fn corpus_cache_dir() -> PathBuf {
+    std::env::var("CORPUS_CACHE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            std::env::var("CARGO_TARGET_TMPDIR")
+                .map(PathBuf::from)
+                .unwrap_or_else(|_| std::env::temp_dir())
+                .join("vitest-linter-corpus")
+        })
+}
+
+fn clone_or_update_project(project: &CorpusProject) -> PathBuf {
+    let cache = corpus_cache_dir().join(project.name);
+
+    if cache.is_dir() {
+        let head = std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&cache)
+            .output()
+            .ok();
+
+        let target = std::process::Command::new("git")
+            .args(["rev-parse", project.commit])
+            .current_dir(&cache)
+            .output()
+            .ok();
+
+        if let (Some(head), Some(target)) = (head, target) {
+            let head_sha = String::from_utf8_lossy(&head.stdout).trim().to_string();
+            let target_sha = String::from_utf8_lossy(&target.stdout).trim().to_string();
+            if head_sha == target_sha && !head_sha.is_empty() {
+                return cache;
+            }
+        }
+
+        let _ = std::process::Command::new("git")
+            .args(["fetch", "--depth", "1", "origin", project.commit])
+            .current_dir(&cache)
+            .status();
+
+        let _ = std::process::Command::new("git")
+            .args(["checkout", project.commit])
+            .current_dir(&cache)
+            .status();
+
+        return cache;
+    }
+
+    std::fs::create_dir_all(cache.parent().unwrap()).unwrap();
+
+    let status = std::process::Command::new("git")
+        .args([
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            project.commit,
+            project.repo_url,
+            cache.to_str().unwrap(),
+        ])
+        .status()
+        .expect("git clone failed — ensure git is installed and network is available");
+
+    assert!(status.success(), "git clone failed for {}", project.name);
+
+    cache
+}
+
+fn lint_corpus(project: &CorpusProject) -> (Vec<vitest_linter::models::Violation>, usize) {
+    let repo_dir = clone_or_update_project(project);
+
+    let paths: Vec<PathBuf> = project
+        .test_dirs
+        .iter()
+        .filter_map(|dir| {
+            let p = repo_dir.join(dir);
+            if p.is_dir() {
+                Some(p)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert!(
+        !paths.is_empty(),
+        "No test directories found for {}",
+        project.name
+    );
+
+    let engine = LintEngine::new().expect("Failed to create lint engine");
+    let (violations, _) = engine.lint_paths(&paths).expect("Linting failed");
+
+    let file_count = paths.iter().map(|p| count_test_files(p)).sum();
+
+    (violations, file_count)
+}
+
+fn count_test_files(dir: &Path) -> usize {
+    walkdir::WalkDir::new(dir)
+        .into_iter()
+        .filter_map(std::result::Result::ok)
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().to_ascii_lowercase();
+            name.ends_with(".test.ts")
+                || name.ends_with(".spec.ts")
+                || name.ends_with(".test.tsx")
+                || name.ends_with(".spec.tsx")
+                || name.ends_with(".test.js")
+                || name.ends_with(".spec.js")
+        })
+        .count()
+}
+
+fn summarize_violations(
+    violations: &[vitest_linter::models::Violation],
+) -> HashMap<String, usize> {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for v in violations {
+        *counts.entry(v.rule_id.clone()).or_default() += 1;
+    }
+    counts
+}
+
+fn assert_no_panic(
+    result: &(Vec<vitest_linter::models::Violation>, usize),
+    project_name: &str,
+) {
+    assert!(
+        !result.0.is_empty() || result.1 > 0,
+        "[{}] Linter returned 0 violations from {} test files — this likely means files were not discovered",
+        project_name,
+        result.1
+    );
+}
+
+fn print_summary(
+    project_name: &str,
+    violations: &[vitest_linter::models::Violation],
+    file_count: usize,
+) {
+    let counts = summarize_violations(violations);
+    eprintln!(
+        "\n[{}] {} files, {} violations:",
+        project_name, file_count, violations.len()
+    );
+    let mut sorted: Vec<_> = counts.iter().collect();
+    sorted.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
+    for (rule, count) in &sorted {
+        eprintln!("  {rule}: {count}");
+    }
+}
+
+#[test]
+#[ignore]
+fn corpus_vitest_no_panic() {
+    let result = lint_corpus(&VITEST_PROJECT);
+    assert_no_panic(&result, "vitest");
+    print_summary("vitest", &result.0, result.1);
+}
+
+#[test]
+#[ignore]
+fn corpus_vitest_stable_counts() {
+    let (violations, file_count) = lint_corpus(&VITEST_PROJECT);
+    assert!(file_count > 0, "Should discover test files");
+
+    let total = violations.len();
+
+    assert!(
+        total > 0,
+        "Vitest's own test suite should produce some violations — got 0 from {file_count} files"
+    );
+
+    assert!(
+        total < file_count * 5,
+        "False-positive rate too high: {total} violations in {file_count} files"
+    );
+
+    print_summary("vitest", &violations, file_count);
+}
+
+#[test]
+#[ignore]
+fn corpus_vitest_no_critical_false_positives() {
+    let (violations, _file_count) = lint_corpus(&VITEST_PROJECT);
+    let counts = summarize_violations(&violations);
+
+    let critical_rules = [
+        "VITEST-MNT-001",
+        "VITEST-MNT-007",
+        "VITEST-VAL-001",
+        "VITEST-VAL-003",
+    ];
+
+    for rule in &critical_rules {
+        let count = counts.get(*rule).copied().unwrap_or(0);
+        assert!(
+            count < 50,
+            "[vitest] {rule} fired {count} times — likely false positives on Vitest's own tests"
+        );
+    }
+}
+
+#[test]
+#[ignore]
+fn corpus_vue_no_panic() {
+    let result = lint_corpus(&VUE_PROJECT);
+    assert_no_panic(&result, "vue");
+    print_summary("vue", &result.0, result.1);
+}
+
+#[test]
+#[ignore]
+fn corpus_vue_stable_counts() {
+    let (violations, file_count) = lint_corpus(&VUE_PROJECT);
+    assert!(file_count > 0, "Should discover test files");
+
+    let total = violations.len();
+
+    assert!(
+        total < file_count * 5,
+        "False-positive rate too high: {total} violations in {file_count} files"
+    );
+
+    print_summary("vue", &violations, file_count);
+}
+
+#[test]
+#[ignore]
+fn corpus_sveltekit_no_panic() {
+    let result = lint_corpus(&SVELTEKIT_PROJECT);
+    assert_no_panic(&result, "sveltekit");
+    print_summary("sveltekit", &result.0, result.1);
+}
+
+#[test]
+#[ignore]
+fn corpus_sveltekit_stable_counts() {
+    let (violations, file_count) = lint_corpus(&SVELTEKIT_PROJECT);
+    assert!(file_count > 0, "Should discover test files");
+
+    let total = violations.len();
+
+    assert!(
+        total < file_count * 5,
+        "False-positive rate too high: {total} violations in {file_count} files"
+    );
+
+    print_summary("sveltekit", &violations, file_count);
+}
+
+#[test]
+#[ignore]
+fn corpus_all_projects_regression() {
+    let projects = [&VITEST_PROJECT, &VUE_PROJECT, &SVELTEKIT_PROJECT];
+    let mut total_violations = 0;
+    let mut total_files = 0;
+
+    for project in &projects {
+        let (violations, file_count) = lint_corpus(project);
+        total_violations += violations.len();
+        total_files += file_count;
+        print_summary(project.name, &violations, file_count);
+    }
+
+    assert!(
+        total_files > 0,
+        "Should discover test files across all corpus projects"
+    );
+
+    assert!(
+        total_violations < total_files * 10,
+        "Aggregate false-positive rate too high: {total_violations} violations across {total_files} files"
+    );
+}

--- a/tests/corpus.rs
+++ b/tests/corpus.rs
@@ -14,13 +14,11 @@ use std::path::{Path, PathBuf};
 
 use vitest_linter::engine::LintEngine;
 
-#[allow(dead_code)]
 struct CorpusProject {
     name: &'static str,
     repo_url: &'static str,
     commit: &'static str,
     test_dirs: &'static [&'static str],
-    allowed_false_positive_rules: &'static [&'static str],
 }
 
 const VITEST_PROJECT: CorpusProject = CorpusProject {
@@ -28,7 +26,6 @@ const VITEST_PROJECT: CorpusProject = CorpusProject {
     repo_url: "https://github.com/vitest-dev/vitest.git",
     commit: "v3.1.2",
     test_dirs: &["test"],
-    allowed_false_positive_rules: &[],
 };
 
 const VUE_PROJECT: CorpusProject = CorpusProject {
@@ -36,7 +33,6 @@ const VUE_PROJECT: CorpusProject = CorpusProject {
     repo_url: "https://github.com/vuejs/core.git",
     commit: "v3.5.13",
     test_dirs: &["packages/vue/__tests__", "packages/reactivity/__tests__"],
-    allowed_false_positive_rules: &[],
 };
 
 const SVELTEKIT_PROJECT: CorpusProject = CorpusProject {
@@ -44,7 +40,6 @@ const SVELTEKIT_PROJECT: CorpusProject = CorpusProject {
     repo_url: "https://github.com/sveltejs/kit.git",
     commit: "5dc4f90c20a8a7a5c9254a7e0a86578a6f06c26d",
     test_dirs: &["packages/kit/test"],
-    allowed_false_positive_rules: &[],
 };
 
 fn corpus_cache_dir() -> PathBuf {
@@ -82,15 +77,19 @@ fn clone_or_update_project(project: &CorpusProject) -> PathBuf {
             }
         }
 
-        let _ = std::process::Command::new("git")
+        let status = std::process::Command::new("git")
             .args(["fetch", "--depth", "1", "origin", project.commit])
             .current_dir(&cache)
-            .status();
+            .status()
+            .expect("git fetch failed");
+        assert!(status.success(), "git fetch failed for {}", project.name);
 
-        let _ = std::process::Command::new("git")
+        let status = std::process::Command::new("git")
             .args(["checkout", project.commit])
             .current_dir(&cache)
-            .status();
+            .status()
+            .expect("git checkout failed");
+        assert!(status.success(), "git checkout failed for {}", project.name);
 
         return cache;
     }
@@ -107,10 +106,23 @@ fn clone_or_update_project(project: &CorpusProject) -> PathBuf {
             project.repo_url,
             cache.to_str().unwrap(),
         ])
-        .status()
-        .expect("git clone failed — ensure git is installed and network is available");
+        .status();
 
-    assert!(status.success(), "git clone failed for {}", project.name);
+    if status.is_err() || !status.unwrap().success() {
+        let status = std::process::Command::new("git")
+            .args(["clone", project.repo_url, cache.to_str().unwrap()])
+            .status()
+            .expect("git clone failed — ensure git is installed and network is available");
+
+        assert!(status.success(), "git clone failed for {}", project.name);
+
+        let status = std::process::Command::new("git")
+            .args(["checkout", project.commit])
+            .current_dir(&cache)
+            .status()
+            .expect("git checkout failed");
+        assert!(status.success(), "git checkout of {} failed for {}", project.commit, project.name);
+    }
 
     cache
 }
@@ -137,7 +149,7 @@ fn lint_corpus(project: &CorpusProject) -> (Vec<vitest_linter::models::Violation
         project.name
     );
 
-    let engine = LintEngine::new().expect("Failed to create lint engine");
+    let engine = LintEngine::new(true).expect("Failed to create lint engine");
     let (violations, _) = engine.lint_paths(&paths).expect("Linting failed");
 
     let file_count = paths.iter().map(|p| count_test_files(p)).sum();
@@ -157,6 +169,8 @@ fn count_test_files(dir: &Path) -> usize {
                 || name.ends_with(".spec.tsx")
                 || name.ends_with(".test.js")
                 || name.ends_with(".spec.js")
+                || name.ends_with(".test.jsx")
+                || name.ends_with(".spec.jsx")
         })
         .count()
 }

--- a/tests/corpus.rs
+++ b/tests/corpus.rs
@@ -121,7 +121,12 @@ fn clone_or_update_project(project: &CorpusProject) -> PathBuf {
             .current_dir(&cache)
             .status()
             .expect("git checkout failed");
-        assert!(status.success(), "git checkout of {} failed for {}", project.commit, project.name);
+        assert!(
+            status.success(),
+            "git checkout of {} failed for {}",
+            project.commit,
+            project.name
+        );
     }
 
     cache


### PR DESCRIPTION
## Summary

Closes #52

Adds golden corpus integration tests that validate vitest-linter against real-world test suites from three major open-source projects:

- **Vitest** (`vitest-dev/vitest` @ `v3.1.2`)
- **Vue** (`vuejs/core` @ `v3.5.13`)
- **SvelteKit** (`sveltejs/kit` @ `5dc4f90`)

### What's included

- `tests/corpus.rs` — 7 `#[ignore]` integration tests:
  - **No-panic tests** for each project (linter doesn't crash on real code)
  - **Stable-count tests** (violation counts bounded by file count × 5)
  - **Critical false-positive guards** (Vitest-specific: `MNT-001`, `MNT-007`, `VAL-001`, `VAL-003` each < 50 fires)
  - **Aggregate regression test** across all 3 projects (bounded by file count × 10)
- CI corpus job with repository caching via `actions/cache@v4`
- `CORPUS_CACHE` env var for local cache control

### How to run

```bash
# Locally (requires git + network):
cargo test --test corpus -- --ignored

# With custom cache dir:
CORPUS_CACHE=~/corpus-repos cargo test --test corpus -- --ignored
```