### PR TITLE
[#70] Distribution — cargo-dist + npm wrapper + GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release
+
+on:
+  push:
+    tags: ["v[0-9]+.*"]
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  dist:
+    name: Build binaries
+    needs: ci
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+          - target: x86_64-apple-darwin
+            runner: macos-13
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-dist
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-dist@0.28.0
+
+      - name: Build with cargo-dist
+        run: cargo dist build --target=${{ matrix.target }} --artifacts=all
+        env:
+          DIST_SIGNING_KEY: ${{ secrets.DIST_SIGNING_KEY }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-${{ matrix.target }}
+          path: target/distrib/*/dist/*
+
+  publish:
+    name: Create GitHub Release + publish npm
+    needs: dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: target/distrib
+          merge-multiple: true
+
+      - name: Install cargo-dist
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-dist@0.28.0
+
+      - name: Create release
+        run: cargo dist publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DIST_SIGNING_KEY: ${{ secrets.DIST_SIGNING_KEY }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish npm wrapper
+        working-directory: npm
+        run: |
+          npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
+          npm publish --access public

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: vitest-linter
   name: vitest-linter
-  description: 'Lint Vitest test files for test smells'
+  description: Detect test smells in Vitest/TypeScript test files
   entry: vitest-linter
   language: rust
   files: '\.(test|spec)\.(ts|tsx|js|jsx)$'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,18 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [[bench]]
 name = "lint_large_corpus"
 harness = false
+
+[profile.dist]
+inherits = "release"
+lto = "thin"
+
+[workspace.metadata.dist]
+cargo-dist-version = "0.28.0"
+ci = "github"
+installers = ["shell", "powershell", "npm"]
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+install-path = "CARGO_HOME"
+install-update = true
+npm-package = "npm"
+merge-tarballs = true
+signing = "sigstore"

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,78 @@
+name: Vitest Linter
+description: Detect test smells in Vitest/TypeScript test files
+branding:
+  icon: search
+  color: yellow
+
+inputs:
+  paths:
+    description: Files or directories to lint
+    required: false
+    default: "."
+  format:
+    description: Output format (terminal, json, sarif)
+    required: false
+    default: sarif
+  no-color:
+    description: Disable colored output
+    required: false
+    default: "false"
+  incremental:
+    description: Only lint changed files
+    required: false
+    default: "false"
+  base:
+    description: Git ref for incremental mode
+    required: false
+    default: HEAD
+
+outputs:
+  sarif-file:
+    description: Path to the generated SARIF file
+    value: ${{ steps.lint.outputs.sarif_file }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install vitest-linter
+      shell: bash
+      run: |
+        if ! command -v vitest-linter &> /dev/null; then
+          VERSION="${GITHUB_ACTION_REF#refs/tags/}"
+          if [ -z "$VERSION" ] || [ "$VERSION" = "$GITHUB_ACTION_REF" ]; then
+            VERSION="latest"
+          fi
+          echo "Installing vitest-linter $VERSION..."
+          if [ "$VERSION" = "latest" ]; then
+            curl --proto '=https' --tlsv1.2 -fsSL https://github.com/Jonathangadeaharder/vitest-linter/releases/latest/download/vitest-linter-installer.sh | sh
+          else
+            curl --proto '=https' --tlsv1.2 -fsSL https://github.com/Jonathangadeaharder/vitest-linter/releases/download/${VERSION}/vitest-linter-installer.sh | sh
+          fi
+        fi
+
+    - name: Run vitest-linter
+      id: lint
+      shell: bash
+      run: |
+        ARGS=()
+        ARGS+=(${{ inputs.paths }})
+        ARGS+=(--format ${{ inputs.format }})
+        if [ "${{ inputs.no-color }}" = "true" ]; then
+          ARGS+=(--no-color)
+        fi
+        if [ "${{ inputs.incremental }}" = "true" ]; then
+          ARGS+=(--incremental --base ${{ inputs.base }})
+        fi
+
+        OUTPUT_FILE="vitest-linter-results.sarif"
+        ARGS+=(--output "$OUTPUT_FILE")
+
+        echo "sarif_file=$OUTPUT_FILE" >> "$GITHUB_OUTPUT"
+
+        vitest-linter "${ARGS[@]}" || true
+
+    - name: Upload SARIF
+      uses: github/codeql-action/upload-sarif@v3
+      if: always() && hashFiles('vitest-linter-results.sarif') != ''
+      with:
+        sarif_file: vitest-linter-results.sarif

--- a/npm/bin/vitest-linter
+++ b/npm/bin/vitest-linter
@@ -1,37 +1,61 @@
 #!/usr/bin/env node
 
 const { execFileSync } = require('child_process');
+const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
+const BIN_NAME = 'vitest-linter';
 const platform = os.platform();
 const arch = os.arch();
 
-const platformMap = {
-  'darwin-x64': 'vitest-linter-darwin-x86_64',
+const optionalDepMap = {
+  'darwin-x64':   'vitest-linter-darwin-x86_64',
   'darwin-arm64': 'vitest-linter-darwin-arm64',
-  'linux-x64': 'vitest-linter-linux-x86_64',
-  'linux-arm64': 'vitest-linter-linux-arm64',
-  'win32-x64': 'vitest-linter-win32-x86_64',
-  'win32-arm64': 'vitest-linter-win32-arm64',
+  'linux-x64':    'vitest-linter-linux-x86_64',
+  'linux-arm64':  'vitest-linter-linux-arm64',
+  'win32-x64':    'vitest-linter-win32-x86_64',
+  'win32-arm64':  'vitest-linter-win32-arm64',
 };
 
 const key = `${platform}-${arch}`;
-const pkg = platformMap[key];
+const ext = platform === 'win32' ? '.exe' : '';
 
-if (!pkg) {
-  console.error(`Unsupported platform: ${key}`);
+function runBin(binPath) {
+  execFileSync(binPath, process.argv.slice(2), { stdio: 'inherit' });
+}
+
+function fail(msg) {
+  console.error(msg);
   process.exit(1);
 }
 
-try {
-  const binPath = require.resolve(`${pkg}/vitest-linter${platform === 'win32' ? '.exe' : ''}`);
-  execFileSync(binPath, process.argv.slice(2), { stdio: 'inherit' });
-} catch (err) {
-  if (typeof err.status === 'number') {
-    process.exit(err.status);
+// 1) Try optionalDependency platform-specific package (cargo-dist approach)
+const pkg = optionalDepMap[key];
+if (pkg) {
+  try {
+    const binPath = require.resolve(`${pkg}/${BIN_NAME}${ext}`);
+    return runBin(binPath);
+  } catch (_) {
+    // optionalDep not installed — try next fallback
   }
-  console.error(`Failed to run vitest-linter for ${key}: ${err.message}`);
-  console.error(`Install the platform package: npm install ${pkg}`);
-  process.exit(1);
+}
+
+// 2) Try locally downloaded binary from postinstall.js
+const localBin = path.join(__dirname, `${BIN_NAME}-bin${ext}`);
+if (fs.existsSync(localBin)) {
+  return runBin(localBin);
+}
+
+// 3) Try globally installed vitest-linter on PATH
+try {
+  const which = require('child_process').execFileSync;
+  // which/where check isn't reliable cross-platform; just exec and catch
+  runBin(BIN_NAME);
+} catch (_) {
+  fail(
+    `vitest-linter binary not found for ${key}.\n` +
+    `Install via npm:  npm install ${pkg || 'vitest-linter'}\n` +
+    `Or via cargo:    cargo install vitest-linter\n`
+  );
 }

--- a/npm/bin/vitest-linter
+++ b/npm/bin/vitest-linter
@@ -22,7 +22,14 @@ const key = `${platform}-${arch}`;
 const ext = platform === 'win32' ? '.exe' : '';
 
 function runBin(binPath) {
-  execFileSync(binPath, process.argv.slice(2), { stdio: 'inherit' });
+  try {
+    execFileSync(binPath, process.argv.slice(2), { stdio: 'inherit' });
+  } catch (err) {
+    if (err.status !== undefined) {
+      process.exit(err.status);
+    }
+    throw err;
+  }
 }
 
 function fail(msg) {
@@ -49,7 +56,6 @@ if (fs.existsSync(localBin)) {
 
 // 3) Try globally installed vitest-linter on PATH
 try {
-  const which = require('child_process').execFileSync;
   // which/where check isn't reliable cross-platform; just exec and catch
   runBin(BIN_NAME);
 } catch (_) {

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,157 @@
+const { execSync } = require("child_process");
+const fs = require("fs");
+const https = require("https");
+const path = require("path");
+const os = require("os");
+
+const REPO = "Jonathangadeaharder/vitest-linter";
+const BIN_NAME = "vitest-linter";
+
+function getPackageVersion() {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "package.json"), "utf8")
+  );
+  return pkg.version;
+}
+
+function getTarget() {
+  const platform = os.platform();
+  const arch = os.arch();
+
+  const platformMap = {
+    darwin: "apple-darwin",
+    linux: "unknown-linux-gnu",
+    win32: "pc-windows-msvc",
+  };
+  const archMap = { x64: "x86_64", arm64: "aarch64" };
+
+  if (!platformMap[platform] || !archMap[arch]) {
+    console.error(`Unsupported platform: ${platform}-${arch}`);
+    process.exit(1);
+  }
+
+  return `${archMap[arch]}-${platformMap[platform]}`;
+}
+
+function getArtifactUrl(version, target) {
+  const ext = os.platform() === "win32" ? ".zip" : ".tar.gz";
+  const name = `${BIN_NAME}-${target}${ext}`;
+  return `https://github.com/${REPO}/releases/download/v${version}/${name}`;
+}
+
+function download(url, dest) {
+  return new Promise((resolve, reject) => {
+    const request = (u, redirects) => {
+      if (redirects > 5) return reject(new Error("Too many redirects"));
+      https.get(
+        u,
+        { headers: { "User-Agent": "node" } },
+        (res) => {
+          if (
+            res.statusCode >= 300 &&
+            res.statusCode < 400 &&
+            res.headers.location
+          ) {
+            return request(res.headers.location, redirects + 1);
+          }
+          if (res.statusCode !== 200) {
+            return reject(new Error(`HTTP ${res.statusCode} downloading ${u}`));
+          }
+          const stream = fs.createWriteStream(dest);
+          res.pipe(stream);
+          stream.on("finish", () => {
+            stream.close();
+            resolve();
+          });
+          stream.on("error", reject);
+        }
+      ).on("error", reject);
+    };
+    request(url, 0);
+  });
+}
+
+function extract(archive, destDir) {
+  if (os.platform() === "win32") {
+    execSync(
+      `powershell -Command "Expand-Archive -Path '${archive}' -DestinationPath '${destDir}' -Force"`,
+      { stdio: "inherit" }
+    );
+  } else {
+    execSync(`tar -xzf "${archive}" -C "${destDir}"`, { stdio: "inherit" });
+  }
+}
+
+async function main() {
+  const version = getPackageVersion();
+  const target = getTarget();
+  const binDir = path.join(__dirname, "bin");
+  const ext = os.platform() === "win32" ? ".exe" : "";
+  const binPath = path.join(binDir, `${BIN_NAME}-bin${ext}`);
+
+  if (fs.existsSync(binPath)) {
+    return;
+  }
+
+  const url = getArtifactUrl(version, target);
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vitest-linter-"));
+  const archiveExt = os.platform() === "win32" ? ".zip" : ".tar.gz";
+  const archivePath = path.join(tmpDir, `dist${archiveExt}`);
+
+  try {
+    console.log(`Downloading vitest-linter v${version} for ${target}...`);
+    await download(url, archivePath);
+    extract(archivePath, tmpDir);
+
+    const extracted = path.join(tmpDir, `${BIN_NAME}${ext}`);
+    if (!fs.existsSync(extracted)) {
+      const entries = fs.readdirSync(tmpDir);
+      const subDir = entries.find((e) =>
+        fs.statSync(path.join(tmpDir, e)).isDirectory()
+      );
+      if (subDir) {
+        const inner = path.join(tmpDir, subDir, `${BIN_NAME}${ext}`);
+        if (fs.existsSync(inner)) {
+          fs.copyFileSync(inner, binPath);
+        }
+      }
+    } else {
+      fs.copyFileSync(extracted, binPath);
+    }
+
+    if (!fs.existsSync(binPath)) {
+      throw new Error(
+        `Binary not found after extraction. Looked for ${binPath}`
+      );
+    }
+
+    fs.chmodSync(binPath, 0o755);
+    console.log(`vitest-linter v${version} installed successfully.`);
+  } catch (err) {
+    console.warn(`Prebuilt binary download failed: ${err.message}`);
+    console.warn("Falling back to cargo install...");
+    try {
+      execSync("cargo install vitest-linter --locked", { stdio: "inherit" });
+      const cargoHome =
+        process.env.CARGO_HOME || path.join(os.homedir(), ".cargo");
+      const cargoBin =
+        os.platform() === "win32"
+          ? path.join(cargoHome, "bin", `${BIN_NAME}.exe`)
+          : path.join(cargoHome, "bin", BIN_NAME);
+      if (fs.existsSync(cargoBin)) {
+        fs.copyFileSync(cargoBin, binPath);
+        console.log("Installed via cargo install.");
+      }
+    } catch (cargoErr) {
+      console.error(`cargo install also failed: ${cargoErr.message}`);
+      console.error(
+        "Please install Rust (https://rustup.rs) or download the binary manually."
+      );
+      process.exit(1);
+    }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+main();

--- a/npm/install.js
+++ b/npm/install.js
@@ -59,6 +59,7 @@ function download(url, dest) {
           }
           const stream = fs.createWriteStream(dest);
           res.pipe(stream);
+          res.on("error", reject);
           stream.on("finish", () => {
             stream.close();
             resolve();
@@ -131,7 +132,7 @@ async function main() {
     console.warn(`Prebuilt binary download failed: ${err.message}`);
     console.warn("Falling back to cargo install...");
     try {
-      execSync("cargo install vitest-linter --locked", { stdio: "inherit" });
+      execSync(`cargo install vitest-linter --version ${version} --locked`, { stdio: "inherit" });
       const cargoHome =
         process.env.CARGO_HOME || path.join(os.homedir(), ".cargo");
       const cargoBin =
@@ -154,4 +155,7 @@ async function main() {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/npm/package.json
+++ b/npm/package.json
@@ -11,6 +11,13 @@
   "bin": {
     "vitest-linter": "bin/vitest-linter"
   },
+  "files": [
+    "bin/",
+    "install.js"
+  ],
+  "scripts": {
+    "postinstall": "node install.js"
+  },
   "os": ["darwin", "linux", "win32"],
   "cpu": ["x64", "arm64"],
   "optionalDependencies": {


### PR DESCRIPTION
Closes #70.

- **cargo-dist** configured for 5 targets (macOS arm64/x86, linux x86/arm64, windows x86) with Sigstore signing
- **npm wrapper** with 3-tier fallback: optionalDep platform package → prebuilt binary download → `cargo install`
- **`.pre-commit-hooks.yaml`** at repo root for pre-commit.com integration
- **`action.yml`** GitHub Action with SARIF output + automatic CodeQL upload
- **Single release workflow** on `vX.Y.Z` tag triggers all builds + npm publish
- Fixed binary naming conflict (`install.js` wrote to same path as JS wrapper)