### PR TITLE
fix: replace pr-agent codebase-review with direct crofai glm-5.1 API call

### DIFF
--- a/.github/workflows/codebase-review.yml
+++ b/.github/workflows/codebase-review.yml
@@ -7,38 +7,64 @@ jobs:
   review:
     runs-on: [self-hosted, macOS]
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Run codebase review
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI.KEY: ${{ secrets.CROFAI_API_KEY }}
-          OPENAI.API_BASE: https://crof.ai/v1
-          CONFIG.MODEL: "openai/glm-5.1"
+          CROFAI_API_KEY: ${{ secrets.CROFAI_API_KEY }}
         run: |
-          DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+          FILES=$(find . -type f \( -name "*.py" -o -name "*.rs" -o -name "*.ts" -o -name "*.svelte" -o -name "*.js" -o -name "*.tsx" -o -name "*.jsx" -o -name "*.go" -o -name "*.rb" -o -name "*.java" -o -name "*.c" -o -name "*.h" -o -name "*.toml" -o -name "*.yaml" -o -name "*.yml" -o -name "*.json" -o -name "*.md" \) ! -path "*/node_modules/*" ! -path "*/target/*" ! -path "*/.git/*" ! -path "*/dist/*" ! -path "*/.venv/*" ! -path "*/__pycache__/*" ! -path "*/vendor/*" | head -100)
 
-          if ! command -v pr-agent &>/dev/null; then
-            echo "ERROR: pr-agent not installed globally. Run: uv tool install pr-agent --with tiktoken --python 3.12"
-            exit 1
-          fi
+          PAYLOAD=""
+          PAYLOAD="$PAYLOAD# Repository: ${{ github.repository }}
+"
+          PAYLOAD="$PAYLOAD# Branch: ${{ github.ref_name }}
+"
+          PAYLOAD="$PAYLOAD# Commit: ${{ github.sha }}
+"
+          PAYLOAD="$PAYLOAD"
+          PAYLOAD="$PAYLOAD## Directory Structure
+"
+          PAYLOAD="$PAYLOAD$(find . -type d ! -path '*/node_modules/*' ! -path '*/target/*' ! -path '*/.git/*' ! -path '*/dist/*' ! -path '*/.venv/*' ! -path '*/__pycache__/*' ! -path '*/vendor/*' | head -50)
+"
+          PAYLOAD="$PAYLOAD"
+          PAYLOAD="$PAYLOAD## Source Files
+"
 
-          BRANCH="tmp/codebase-review-$(date +%s)"
-          git checkout --orphan "$BRANCH"
-          git rm -rf . >/dev/null 2>&1 || true
-          echo "# Placeholder" > README.md
-          git add README.md
-          git commit -m "empty"
-          git push origin "$BRANCH"
+          while IFS= read -r file; do
+            size=$(wc -c < "$file" 2>/dev/null || echo 0)
+            if [ "$size" -gt 0 ] && [ "$size" -lt 50000 ]; then
+              PAYLOAD="$PAYLOAD
+### $file
+$(head -200 "$file")
+"
+            fi
+          done <<< "$FILES"
 
-          PR_URL=$(gh pr create --base "$BRANCH" --head "$DEFAULT_BRANCH" --title "Codebase Review $(date -u +%Y-%m-%d)" --body "Automated full codebase review")
+          echo "$PAYLOAD" > /tmp/review-input.txt
+          echo "Input size: $(wc -c < /tmp/review-input.txt) bytes"
 
-          pr-agent describe --pr_url="$PR_URL"
-          pr-agent review --pr_url="$PR_URL"
+          RESPONSE=$(curl -s https://crof.ai/v1/chat/completions \
+            -H "Authorization: Bearer $CROFAI_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"model\": \"openai/glm-5.1\",
+              \"messages\": [
+                {
+                  \"role\": \"system\",
+                  \"content\": \"You are an expert code reviewer. Perform a thorough codebase review covering: 1) Architecture & design patterns, 2) Security issues, 3) Code quality & maintainability, 4) Potential bugs, 5) Performance concerns, 6) Testing coverage gaps. Be specific with file paths and line numbers. Output as markdown with clear sections.\"
+                },
+                {
+                  \"role\": \"user\",
+                  \"content\": $(cat /tmp/review-input.txt | jq -Rs .)
+                }
+              ],
+              \"max_tokens\": 8192
+            }")
 
-          gh pr close "$PR_URL" -d
-          git push origin --delete "$BRANCH" || true
+          echo "## Codebase Review Results" >> $GITHUB_STEP_SUMMARY
+          echo "$RESPONSE" | jq -r '.choices[0].message.content // "Error: " + (.error.message // "Unknown error")' >> $GITHUB_STEP_SUMMARY
+          echo "Review complete. Check $GITHUB_STEP_SUMMARY for results."


### PR DESCRIPTION
Replaces pr-agent orphan-branch PR workflow with direct curl API call to crofai glm-5.1.

- Removes pr-agent, gh, and orphan-branch dependency
- `permissions: contents: read` only (no PR creation)
- Collects source files (up to 100, <50KB) + directory tree
- Sends to `https://crof.ai/v1/chat/completions` with `openai/glm-5.1`
- Outputs review to `$GITHUB_STEP_SUMMARY`
- Uses `CROFAI_API_KEY` secret instead of `OPENAI.KEY`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review workflow in development infrastructure to enhance code analysis efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jonathangadeaharder/vitest-linter/pull/89)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->