### PR TITLE
fix: FocusedTestRule (VITEST-MNT-007) fires on Playwright test.only/test.describe.only

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -271,23 +271,56 @@ impl TsParser {
 
         match func_name.as_str() {
             "test" | "it" | "fit" | "xit" => {
-                let uses_fit_or_xit =
-                    full_callee.starts_with("fit") || full_callee.starts_with("xit");
-                if let Some(tb) = Self::extract_test(
-                    node,
-                    source,
-                    path,
-                    describe_depth,
-                    is_skip,
-                    is_only,
-                    uses_fit_or_xit,
-                ) {
-                    ctx.test_blocks.push(tb);
-                }
-                // Recurse into body with Test scope so nested vi.* calls
-                // (rare, and a smell themselves) get tagged correctly.
-                if let Some(body) = Self::callback_body(node) {
-                    Self::collect(body, source, path, describe_depth, MockScope::Test, ctx);
+                // Playwright: test.describe / test.describe.only are describe blocks
+                if full_callee.starts_with("test.describe") {
+                    let name_node = node
+                        .child_by_field_name("arguments")
+                        .and_then(|args| args.named_child(0));
+                    let name = name_node
+                        .and_then(|n| Self::string_value(n, source))
+                        .unwrap_or_default();
+                    let title_is_template_literal =
+                        name_node.is_some_and(|n| n.kind() == "template_string");
+                    let title_is_empty = name.is_empty();
+                    let is_async = node
+                        .child_by_field_name("arguments")
+                        .and_then(|args| args.named_child(1))
+                        .is_some_and(|cb| {
+                            let text = cb.utf8_text(source.as_bytes()).unwrap_or("");
+                            text.starts_with("async")
+                        });
+                    ctx.describe_blocks.push(DescribeBlock {
+                        name,
+                        file_path: path.to_path_buf(),
+                        line: node.start_position().row + 1,
+                        is_only,
+                        depth: describe_depth,
+                        title_is_template_literal,
+                        title_is_empty,
+                        is_async,
+                    });
+                    if let Some(body) = Self::callback_body(node) {
+                        Self::collect(body, source, path, describe_depth + 1, scope, ctx);
+                    } else {
+                        Self::collect(node, source, path, describe_depth, scope, ctx);
+                    }
+                } else {
+                    let uses_fit_or_xit =
+                        full_callee.starts_with("fit") || full_callee.starts_with("xit");
+                    if let Some(tb) = Self::extract_test(
+                        node,
+                        source,
+                        path,
+                        describe_depth,
+                        is_skip,
+                        is_only,
+                        uses_fit_or_xit,
+                    ) {
+                        ctx.test_blocks.push(tb);
+                    }
+                    if let Some(body) = Self::callback_body(node) {
+                        Self::collect(body, source, path, describe_depth, MockScope::Test, ctx);
+                    }
                 }
             }
             "describe" | "fdescribe" | "xdescribe" => {
@@ -1931,6 +1964,46 @@ test('with waitForTimeout', async ({ page }) => {
                 .iter()
                 .any(|c| c.call_name.contains("waitForTimeout")),
             "Expected waitForTimeout call to be tracked"
+        );
+    }
+
+    #[test]
+    fn parse_playwright_test_describe_only_creates_describe_block() {
+        let dir = write_temp(
+            r#"
+import { test, expect } from '@playwright/test';
+
+test.describe.only('focused group', () => {
+    test('inside', async ({ page }) => {
+        await expect(page).toHaveTitle(/app/);
+    });
+});
+"#,
+            "pw-describe-only.spec.ts",
+        );
+        let path = dir.path().join("pw-describe-only.spec.ts");
+        let parser = TsParser::new().unwrap();
+        let module = parser.parse_file(&path).unwrap();
+
+        assert_eq!(module.runtime, TestRuntime::Playwright);
+        assert_eq!(
+            module.describe_blocks.len(),
+            1,
+            "test.describe.only should create a DescribeBlock"
+        );
+        assert_eq!(module.describe_blocks[0].name, "focused group");
+        assert!(
+            module.describe_blocks[0].is_only,
+            "Describe block should have is_only = true"
+        );
+        assert_eq!(
+            module.test_blocks.len(),
+            1,
+            "Nested test should be parsed as TestBlock"
+        );
+        assert!(
+            !module.test_blocks[0].is_only,
+            "Nested test should NOT have is_only"
         );
     }
 }

--- a/tests/fixtures/mnt_007_focused_test/playwright_test_only/expected.json
+++ b/tests/fixtures/mnt_007_focused_test/playwright_test_only/expected.json
@@ -1,0 +1,26 @@
+[
+  {
+    "rule_id": "VITEST-MNT-007",
+    "rule_name": "FocusedTestRule",
+    "severity": "Error",
+    "category": "Maintenance",
+    "message": "Focused describe 'focused group' uses .only — all other tests in this file will be skipped",
+    "file_path": "tests/fixtures/mnt_007_focused_test/playwright_test_only/input.spec.ts",
+    "line": 3,
+    "col": null,
+    "suggestion": "Remove .only before committing. Focused tests mask failures in CI",
+    "test_name": null
+  },
+  {
+    "rule_id": "VITEST-MNT-007",
+    "rule_name": "FocusedTestRule",
+    "severity": "Error",
+    "category": "Maintenance",
+    "message": "Focused test 'standalone focused test' uses .only — all other tests in this file will be skipped",
+    "file_path": "tests/fixtures/mnt_007_focused_test/playwright_test_only/input.spec.ts",
+    "line": 9,
+    "col": null,
+    "suggestion": "Remove .only before committing. Focused tests mask failures in CI",
+    "test_name": "standalone focused test"
+  }
+]

--- a/tests/fixtures/mnt_007_focused_test/playwright_test_only/input.spec.ts
+++ b/tests/fixtures/mnt_007_focused_test/playwright_test_only/input.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test.describe.only('focused group', () => {
+    test('inside focused group', async ({ page }) => {
+        await expect(page).toHaveTitle(/app/);
+    });
+});
+
+test.only('standalone focused test', async ({ page }) => {
+    await expect(page).toHaveTitle(/app/);
+});
+
+test('normal test without only', async ({ page }) => {
+    await expect(page).toHaveTitle(/app/);
+});

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3724,36 +3724,37 @@ test('clean pw test', async ({ page }) => {
             rule_id
         );
     }
+}
 
-    #[test]
-    fn cross_runtime_rules_fire_on_playwright() {
-        let dir = TempDir::new().unwrap();
-        let path = write_fixture(
-            &dir,
-            "pw-no-assert.spec.ts",
-            r#"
+#[test]
+fn cross_runtime_rules_fire_on_playwright() {
+    let dir = TempDir::new().unwrap();
+    let path = write_fixture(
+        &dir,
+        "pw-no-assert.spec.ts",
+        r#"
 import { test } from '@playwright/test';
 
 test('no assertions pw', async ({ page }) => {
     await page.goto('/');
 });
 "#,
-        );
-        let engine = LintEngine::new(true).unwrap();
-        let (violations, _) = engine.lint_paths(&[path]).unwrap();
-        assert!(
-            find_violation(&violations, "VITEST-MNT-001").is_some(),
-            "NoAssertionRule should fire on Playwright files too"
-        );
-    }
+    );
+    let engine = LintEngine::new(true).unwrap();
+    let (violations, _) = engine.lint_paths(&[path]).unwrap();
+    assert!(
+        find_violation(&violations, "VITEST-MNT-001").is_some(),
+        "NoAssertionRule should fire on Playwright files too"
+    );
+}
 
-    #[test]
-    fn mnt008_global_stub_without_cleanup() {
-        let dir = TempDir::new().unwrap();
-        let path = write_fixture(
-            &dir,
-            "global_stub.test.ts",
-            r#"
+#[test]
+fn mnt008_global_stub_without_cleanup() {
+    let dir = TempDir::new().unwrap();
+    let path = write_fixture(
+        &dir,
+        "global_stub.test.ts",
+        r#"
 import { vi, test, expect } from 'vitest';
 
 const mockFetch = vi.fn();
@@ -3763,23 +3764,23 @@ test('uses global fetch', () => {
     expect(1).toBe(1);
 });
 "#,
-        );
-        let engine = LintEngine::new(true).unwrap();
-        let (violations, _) = engine.lint_paths(&[path]).unwrap();
-        let v = find_violation(&violations, "VITEST-MNT-008");
-        assert!(
-            v.is_some(),
-            "Expected VITEST-MNT-008 for global.fetch stub without cleanup"
-        );
-    }
+    );
+    let engine = LintEngine::new(true).unwrap();
+    let (violations, _) = engine.lint_paths(&[path]).unwrap();
+    let v = find_violation(&violations, "VITEST-MNT-008");
+    assert!(
+        v.is_some(),
+        "Expected VITEST-MNT-008 for global.fetch stub without cleanup"
+    );
+}
 
-    #[test]
-    fn mnt008_vi_stub_global_without_unstub() {
-        let dir = TempDir::new().unwrap();
-        let path = write_fixture(
-            &dir,
-            "stub_global.test.ts",
-            r#"
+#[test]
+fn mnt008_vi_stub_global_without_unstub() {
+    let dir = TempDir::new().unwrap();
+    let path = write_fixture(
+        &dir,
+        "stub_global.test.ts",
+        r#"
 import { vi, test, expect } from 'vitest';
 
 vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true })));
@@ -3788,15 +3789,14 @@ test('uses stubbed fetch', () => {
     expect(1).toBe(1);
 });
 "#,
-        );
-        let engine = LintEngine::new(true).unwrap();
-        let (violations, _) = engine.lint_paths(&[path]).unwrap();
-        let v = find_violation(&violations, "VITEST-MNT-008");
-        assert!(
-            v.is_some(),
-            "Expected VITEST-MNT-008 for vi.stubGlobal without vi.unstubAllGlobals"
-        );
-    }
+    );
+    let engine = LintEngine::new(true).unwrap();
+    let (violations, _) = engine.lint_paths(&[path]).unwrap();
+    let v = find_violation(&violations, "VITEST-MNT-008");
+    assert!(
+        v.is_some(),
+        "Expected VITEST-MNT-008 for vi.stubGlobal without vi.unstubAllGlobals"
+    );
 }
 
 #[test]
@@ -3888,4 +3888,38 @@ test('chained css selectors', async ({ page }) => {
         find_violation(&violations, "VITEST-PW-011").is_some(),
         "PW-011 should flag hard CSS class chain"
     );
+}
+
+#[test]
+fn mnt007_playwright_fixture_violates() {
+    let fixture_dir = std::path::Path::new("tests/fixtures/mnt_007_focused_test/playwright_test_only");
+    assert!(fixture_dir.exists(), "Fixture directory should exist");
+    let input_path = fixture_dir.join("input.spec.ts");
+    assert!(input_path.exists(), "Fixture input file should exist");
+
+    let engine = LintEngine::new(true).unwrap();
+    let (violations, _) = engine.lint_paths(&[input_path]).unwrap();
+
+    let mnt007: Vec<_> = violations
+        .iter()
+        .filter(|v| v.rule_id == "VITEST-MNT-007")
+        .collect();
+
+    assert_eq!(mnt007.len(), 2, "Expected 2 FocusedTestRule violations");
+
+    let describe_v: Vec<_> = mnt007
+        .iter()
+        .filter(|v| v.test_name.is_none())
+        .collect();
+    let test_v: Vec<_> = mnt007
+        .iter()
+        .filter(|v| v.test_name.is_some())
+        .collect();
+
+    assert_eq!(describe_v.len(), 1, "Expected 1 describe.only violation");
+    assert_eq!(test_v.len(), 1, "Expected 1 test.only violation");
+
+    assert_eq!(describe_v[0].line, 3);
+    assert_eq!(test_v[0].line, 9);
+    assert_eq!(test_v[0].test_name.as_deref(), Some("standalone focused test"));
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3892,7 +3892,8 @@ test('chained css selectors', async ({ page }) => {
 
 #[test]
 fn mnt007_playwright_fixture_violates() {
-    let fixture_dir = std::path::Path::new("tests/fixtures/mnt_007_focused_test/playwright_test_only");
+    let fixture_dir =
+        std::path::Path::new("tests/fixtures/mnt_007_focused_test/playwright_test_only");
     assert!(fixture_dir.exists(), "Fixture directory should exist");
     let input_path = fixture_dir.join("input.spec.ts");
     assert!(input_path.exists(), "Fixture input file should exist");
@@ -3907,19 +3908,16 @@ fn mnt007_playwright_fixture_violates() {
 
     assert_eq!(mnt007.len(), 2, "Expected 2 FocusedTestRule violations");
 
-    let describe_v: Vec<_> = mnt007
-        .iter()
-        .filter(|v| v.test_name.is_none())
-        .collect();
-    let test_v: Vec<_> = mnt007
-        .iter()
-        .filter(|v| v.test_name.is_some())
-        .collect();
+    let describe_v: Vec<_> = mnt007.iter().filter(|v| v.test_name.is_none()).collect();
+    let test_v: Vec<_> = mnt007.iter().filter(|v| v.test_name.is_some()).collect();
 
     assert_eq!(describe_v.len(), 1, "Expected 1 describe.only violation");
     assert_eq!(test_v.len(), 1, "Expected 1 test.only violation");
 
     assert_eq!(describe_v[0].line, 3);
     assert_eq!(test_v[0].line, 9);
-    assert_eq!(test_v[0].test_name.as_deref(), Some("standalone focused test"));
+    assert_eq!(
+        test_v[0].test_name.as_deref(),
+        Some("standalone focused test")
+    );
 }


### PR DESCRIPTION
## Summary

Fixes Part A6 of #72. `FocusedTestRule` now correctly fires on Playwright `test.only(...)` and `test.describe.only(...)` from `@playwright/test`.

## Changes

1. **`src/parser.rs`** — In `handle_call`, redirect Playwright's `test.describe` / `test.describe.only` calls to the describe block handler (they were being parsed as TestBlocks since `parse_callee` returns `base = "test"`).

2. **`tests/integration_tests.rs`** — Fixed 3 nested `#[test]` functions inside `vitest_rules_do_not_fire_on_playwright_files` that were dead code (Rust `cannot test inner items`). Extracted to top-level functions. Added `mnt007_playwright_fixture_violates` test.

3. **`tests/fixtures/mnt_007_focused_test/playwright_test_only/`** — Added fixture with `input.spec.ts` (triggers both `test.describe.only` and `test.only`) and `expected.json`.

4. **`src/parser.rs`** — Added parser unit test `parse_playwright_test_describe_only_creates_describe_block` to verify `test.describe.only` creates DescribeBlock with `is_only = true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly detect Playwright focused tests: both standalone `.only` tests and `describe.only` groups are recognized; `.only` is now scoped to the describe block itself.

* **Tests**
  * Added fixtures and integration tests validating focused-test detection and expected lint violations for Playwright scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jonathangadeaharder/vitest-linter/pull/91)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->