### PR TITLE
feat: add SonarCloud integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,12 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Coverage vitest-linter
-        run: cargo +nightly llvm-cov --fail-under-lines 90
+        run: cargo +nightly llvm-cov --lcov --output-path coverage.lcov --fail-under-lines 90
+      - name: Upload coverage to SonarCloud
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.lcov
 
   audit:
     name: Audit
@@ -70,6 +75,23 @@ jobs:
         run: cargo install cargo-audit --locked
       - name: Audit dependencies
         run: cargo audit
+
+  sonarcloud:
+    name: SonarCloud
+    needs: coverage
+    runs-on: ${{ github.event_name == 'push' && 'self-hosted' || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v3
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   dogfood:
     name: Dogfood

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
   sonarcloud:
     name: SonarCloud
     needs: coverage
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
     runs-on: ${{ github.event_name == 'push' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=Jonathangadeaharder_vitest-linter
+sonar.organization=jonathangadeaharder
+sonar.sources=src
+sonar.tests=tests
+sonar.language=rust
+sonar.sourceEncoding=UTF-8
+sonar.coverageReportPaths=coverage.lcov

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,5 @@ sonar.projectKey=Jonathangadeaharder_vitest-linter
 sonar.organization=jonathangadeaharder
 sonar.sources=src
 sonar.tests=tests
-sonar.language=rust
 sonar.sourceEncoding=UTF-8
-sonar.coverageReportPaths=coverage.lcov
+sonar.rust.lcov.reportPaths=coverage.lcov


### PR DESCRIPTION
## Summary
- Add `sonar-project.properties` for SonarCloud Rust analysis
- Update CI coverage job to generate `lcov` format for SonarCloud
- Add `sonarcloud` job that depends on coverage, downloads artifact, runs SonarSource scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI to produce a coverage artifact with an enforced minimum line-coverage threshold.
  * Added automated static analysis integration to run after coverage and upload reports for project quality tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jonathangadeaharder/vitest-linter/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->