### PR TITLE
docs: remove stale duplicate config, update vscode rule count

### DIFF
--- a/.pre-commit-hooks 2.yaml
+++ b/.pre-commit-hooks 2.yaml
@@ -1,7 +1,0 @@
-- id: vitest-linter
-  name: vitest-linter
-  description: Detect test smells in Vitest/TypeScript test files
-  entry: vitest-linter
-  language: rust
-  files: '\.(test|spec)\.(ts|tsx|js|jsx)$'
-  types: [file]

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -8,7 +8,7 @@ Zero-config test-smell diagnostics for Vitest projects, directly in VS Code.
 
 - Activates automatically when editing test files (`.test.ts`, `.spec.ts`, `.test.js`, etc.)
 - Runs [vitest-linter](https://github.com/Jonathangadeaharder/vitest-linter) on save (or on type) and shows diagnostics in the Problems panel
-- Supports 49 lint rules across flakiness, maintenance, structure, dependencies, and validation categories
+- Supports 65+ lint rules across flakiness, maintenance, structure, dependencies, validation, and Playwright categories
 - Configurable rule severity overrides, include/exclude globs, and run trigger
 
 ## Prerequisites


### PR DESCRIPTION
## Summary

- Delete stale duplicate `.pre-commit-hooks 2.yaml` (leftover copy of `.pre-commit-hooks.yaml`)
- Update vscode/README.md rule count from 49 to 65+ (PW rules added since original doc)
- SonarCloud project key verified correct (`Jonathangadeaharder_vitest-linter`)
- No AGENTS.md in project — no cargo tool conflicts
- No outdated CI/setup refs in docs/ specs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated VS Code extension README to reflect comprehensive lint rule coverage expansion, now supporting 65+ lint rules across multiple categories including flakiness, maintenance, structure, dependencies, validation, and Playwright testing framework support.

* **Chores**
  * Removed pre-commit hook configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jonathangadeaharder/vitest-linter/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->