### PR TITLE
fix: aggressive project cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 target/
 .DS_Store
 mutants.out/
+mutants.out.old/
+coverage/
+*.lcov
+*.lockfile
 .worktrees/

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,0 @@
-- id: vitest-linter
-  name: vitest-linter
-  description: Detect test smells in Vitest/TypeScript test files
-  entry: vitest-linter
-  language: rust
-  files: '\.(test|spec)\.(ts|tsx|js|jsx)$'


### PR DESCRIPTION
## Summary

- Add missing patterns to `.gitignore`: `coverage/`, `*.lcov`, `*.lockfile`, `mutants.out.old/`
- Remove tracked `.pre-commit-hooks.yaml` from git tracking (file kept locally)
- Delete untracked `mutants.out.old/` directory