### PR TITLE
docs: add architecture ADRs + Playwright support design spec

### DIFF
--- a/docs/architecture/ADR-001-project-architecture.md
+++ b/docs/architecture/ADR-001-project-architecture.md
@@ -1,0 +1,54 @@
+# ADR-001: Project Architecture
+
+**Status:** Accepted  
+**Date:** 2026-05-17  
+**Deciders:** @Jonathangadeaharder
+
+## Context
+
+vitest-linter needs a fast, portable CLI tool for detecting test smells in Vitest test suites. It must be installable via `cargo install`, npm, or prebuilt binary, and integrate with GitHub Actions, VS Code, and CI pipelines via SARIF output.
+
+## Decision
+
+**Rust CLI tool** managed by Cargo. Architecture is a single-crate workspace with these layers:
+
+```
+src/
+  main.rs          # CLI entrypoint (clap arg parsing)
+  lib.rs           # Public API: run_cli(), build_sarif()
+  config.rs        # .vitest-linter.toml + package.json merging
+  parser.rs        # Tree-sitter TypeScript/TSX AST extraction
+  engine.rs        # LintEngine: file discovery → parse → rule eval → suppression
+  models.rs        # Core types: Violation, ParsedModule, TestBlock, etc.
+  suppression.rs   # Inline comment suppression parsing
+  rules/
+    mod.rs         # Rule trait, v1_0_rules(), all_rules() registration
+    flakiness.rs   # VITEST-FLK-* rules
+    maintenance.rs # VITEST-MNT-* rules
+    no_rules.rs    # VITEST-NO-* rules
+    prefer.rs      # VITEST-PREF-* rules
+    require.rs     # VITEST-REQ-* rules
+    consistency.rs # VITEST-CON-* rules
+    validation.rs  # VITEST-VAL-* rules
+    dependencies.rs# VITEST-DEP-* rules
+    playwright.rs  # VITEST-PW-* rules
+    selector_classifier.rs # Playwright selector heuristics
+tests/
+  integration_tests.rs  # Integration tests via tempfile
+  corpus.rs             # Corpus-based regression tests
+benches/
+  lint_large_corpus.rs  # Criterion benchmarks
+```
+
+Key architectural properties:
+- **Two-phase pipeline:** Phase 1 = parallel file discovery + tree-sitter parsing. Phase 2 = sequential rule evaluation with shared `ModuleGraph`.
+- **Rule trait:** Every rule is a struct implementing `Rule` with `id()`, `name()`, `severity()`, `category()`, `check()`, and `applies_to_runtime()`.
+- **Runtime gating:** `TestRuntime` enum (Vitest/Playwright/Unknown) detected from import statements. Rules can opt out per runtime.
+- **Suppression:** Inline `// vitest-linter-disable-next-line` and `// vitest-linter-disable/enable` range comments.
+- **Config:** Walk-up `.vitest-linter.toml` discovery, merged with `package.json` `"vitest-linter"` key.
+
+## Consequences
+
+- Single binary deployment via `cargo-dist` / npm wrapper.
+- Rules must be stateless (all state in `ParsedModule` + `Config` + `ModuleGraph`).
+- Adding a rule requires: new struct in existing category file, registration in `mod.rs`, integration test, and (for parser-backed rules) parser field.

--- a/docs/architecture/ADR-002-toolchain.md
+++ b/docs/architecture/ADR-002-toolchain.md
@@ -1,0 +1,36 @@
+# ADR-002: Toolchain
+
+**Status:** Accepted  
+**Date:** 2026-05-17  
+**Deciders:** @Jonathangadeaharder
+
+## Context
+
+The project needs a consistent Rust toolchain for building, linting, formatting, and auditing. Multiple toolchains are involved (stable for build/test, nightly for clippy pedantic checks and coverage).
+
+## Decision
+
+| Tool | Version | Config Source | Purpose |
+|------|---------|---------------|---------|
+| `cargo` (Rust) | edition 2021, stable | `Cargo.toml` | Build, test, bench |
+| `rustfmt` | nightly via dtolnay/rust-toolchain | `rustfmt.toml` (project root) | Formatting enforcement |
+| `clippy` | nightly with `clippy::all`, `pedantic`, `nursery` | `.cargo/config.toml` | Linting (zero-warnings gate) |
+| `cargo-llvm-cov` | nightly with `llvm-tools-preview` | CLI args | Branch coverage (`--fail-under-lines 90`) |
+| `cargo-audit` | stable | `Cargo.lock` | Dependency vulnerability scanning |
+| `cargo-mutants` | stable | `.cargo/mutants.toml` | Mutation testing (score ≥75% gate) |
+| `cargo-dist` | 0.28.0 | `Cargo.toml` (workspace metadata) | Binary release + npm publishing |
+| `cargo-deny` | stable (planned) | `deny.toml` (planned) | License + duplicate dep checking |
+| `structurelint` | Go 1.24 | `.structurelint.yml` | Repo structure linting |
+
+CI workflows (`./.github/workflows/`):
+- `ci.yml`: fmt → clippy → test → coverage → audit → dogfood → repo-structure → required-checks
+- `merge-gate.yml`: CI + SonarCloud
+- `release.yml`: cargo-dist multi-arch builds
+- `mutants.yml`: Scheduled mutation testing (self-hosted runner)
+- `pr-agent.yml`: PR-Agent for automated review (LM Studio, self-hosted)
+
+## Consequences
+
+- Nightly toolchain required for clippy + coverage CI jobs (stable for everything else).
+- Rust cache (`Swatinem/rust-cache@v2`) essential to keep CI under 5 min.
+- Self-hosted macOS runner for push events (faster than GitHub-hosted).

--- a/docs/architecture/ADR-003-quality-gates.md
+++ b/docs/architecture/ADR-003-quality-gates.md
@@ -1,0 +1,53 @@
+# ADR-003: Quality Gates
+
+**Status:** Accepted  
+**Date:** 2026-05-17  
+**Deciders:** @Jonathangadeaharder
+
+## Context
+
+The project must enforce code quality at PR time and merge time. Quality gates must cover formatting, linting, testing, coverage, security, and structural integrity.
+
+## Decision
+
+### PR Gate (`pr-gate.yml`)
+
+Required checks (all must pass before merge):
+
+| Check | Tool | Threshold | Runner |
+|-------|------|-----------|--------|
+| Format | `cargo fmt --check` | Zero diffs | ubuntu-latest / self-hosted |
+| Clippy | `cargo +nightly clippy --lib -- -W clippy::all -W clippy::pedantic -W clippy::nursery` | Zero warnings | ubuntu-latest / self-hosted |
+| Test | `cargo test` | All pass | ubuntu-latest / self-hosted |
+| Coverage | `cargo +nightly llvm-cov --lcov --output-path coverage.lcov --fail-under-lines 90` | Lines ≥90% | ubuntu-latest / self-hosted |
+| Audit | `cargo audit` | Zero vulns | ubuntu-latest / self-hosted |
+| Dogfood | Run release binary on test file with intentional smells | Violations detected | ubuntu-latest / self-hosted |
+| Repo Structure | `structurelint .` | All rules pass | ubuntu-latest / self-hosted |
+
+Aggregated `required-checks` job gates the merge queue — any sub-job failure blocks merge.
+
+### Merge Gate (`merge-gate.yml`)
+
+Currently merged into `ci.yml` (no separate merge-gate.yml). Extends PR gate with:
+- SonarCloud scanning (fetches coverage.lcov artifact)
+- CodeRabbit review (automated, no human reviewer)
+- PR-Agent fallback when CodeRabbit rate-limited
+
+### Branch Protection
+
+`main` branch requires:
+- `Required Checks (PR)` status check passing
+- 1 approving review (CodeRabbit or PR-Agent)
+- Dismiss stale reviews on new pushes
+
+### Self-Hosted Runner
+
+- macOS runner configured for push events (avoids GitHub-hosted macOS minute costs).
+- Used by: mutation testing, release publish step.
+
+## Consequences
+
+- PRs that reduce line coverage below 90% are blocked.
+- PRs with clippy warnings are blocked (pedantic + nursery).
+- PR-Agent requires `ENABLE_PR_AGENT=true` repo variable and self-hosted LM Studio.
+- SonarCloud requires `SONAR_TOKEN` secret.

--- a/docs/architecture/ADR-004-testing-strategy.md
+++ b/docs/architecture/ADR-004-testing-strategy.md
@@ -1,0 +1,50 @@
+# ADR-004: Testing Strategy
+
+**Status:** Accepted  
+**Date:** 2026-05-17  
+**Deciders:** @Jonathangadeaharder
+
+## Context
+
+vitest-linter is a linting tool — correctness of every rule is critical. False positives erode trust, false negatives leave bugs undetected. Testing strategy must cover unit, integration, mutation, and regression testing.
+
+## Decision
+
+### Test Levels
+
+| Level | Tool | Location | Scope |
+|-------|------|----------|-------|
+| Unit | `cargo test` (inline `#[cfg(test)]` modules) | Each `src/` module | Parser methods, config parsing, suppression logic, model invariants |
+| Integration | `cargo test` (separate `tests/` dir) | `tests/integration_tests.rs` (4000+ lines, 100+ tests) | Full end-to-end: write tempfile → parse → lint → assert violations |
+| Corpus | `cargo test` | `tests/corpus.rs` | Regression tests against real-world `.test.ts` fixtures |
+| Mutation | `cargo-mutants` | `.cargo/mutants.toml` (excludes benches, tests) | Score ≥75% gate in scheduled CI |
+| Benchmark | `cargo bench` (criterion) | `benches/lint_large_corpus.rs` | Performance regression detection |
+
+### Coverage Requirements
+
+- **Tool:** `cargo +nightly llvm-cov` with `--lcov` output.
+- **Threshold:** Line coverage ≥90% (enforced in CI via `--fail-under-lines 90`).
+- **Report format:** `lcov` (consumed by SonarCloud).
+- **Project key (SonarCloud):** `Jonathangadeaharder_vitest-linter`
+
+### Mutation Testing
+
+- **Tool:** `cargo-mutants` (via `taiki-e/install-action`).
+- **Schedule:** Daily at 3 AM UTC (`cron: "0 3 * * *"`), also `workflow_dispatch`.
+- **Runner:** Self-hosted (cost-effective for long-running mutation analysis).
+- **Exclusions:** `benches/`, `tests/` (test harness code itself excluded).
+- **Threshold:** Score ≥75%. Fails if below.
+
+### Test Patterns
+
+- **Integration tests:** Write temp `.test.ts` file → `LintEngine::new(true)` → `lint_paths()` → find specific `rule_id` violation.
+- **Parser tests:** Write temp file → `TsParser::parse_file()` → assert field values on `ParsedModule`.
+- **Suppression tests:** Include `// vitest-linter-disable-next-line` comments in fixture → assert violation is suppressed.
+- **CLI tests:** `run_cli()` with various `--format` flags, assert JSON/terminal/sarif output.
+
+## Consequences
+
+- Every new rule requires at minimum: 1 positive integration test (triggers) + 1 negative test (doesn't trigger on clean code).
+- Parser changes require inline unit tests for new detection functions.
+- Mutation testing runs daily, not on every PR (too expensive at 5+ min).
+- Line coverage of 90% is achievable (current is 98.95% lines, 92.42% branches).

--- a/docs/architecture/ADR-005-lint-rule-architecture.md
+++ b/docs/architecture/ADR-005-lint-rule-architecture.md
@@ -1,0 +1,90 @@
+# ADR-005: Lint Rule Architecture
+
+**Status:** Accepted  
+**Date:** 2026-05-17  
+**Deciders:** @Jonathangadeaharder
+
+## Context
+
+vitest-linter must support 65 lint rules (8 stable + 57 unstable) across 7 categories. Rules need to analyze tree-sitter AST data, respect config overrides, support inline suppression, and gate by test runtime. The architecture must make adding new rules mechanical.
+
+## Decision
+
+### Rule Trait
+
+Every rule implements this trait:
+
+```rust
+pub trait Rule {
+    fn id(&self) -> &'static str;              // e.g. "VITEST-FLK-001"
+    fn name(&self) -> &'static str;            // e.g. "TimeoutRule"
+    fn severity(&self) -> Severity;            // Error | Warning | Info
+    fn category(&self) -> Category;            // Flakiness | Maintenance | ...
+    fn check(&self, module: &ParsedModule, ctx: &LintContext<'_>, graph: &ModuleGraph) -> Vec<Violation>;
+    fn applies_to_runtime(&self, runtime: TestRuntime) -> bool;  // default: !Playwright
+}
+```
+
+### Rule Registry
+
+Two registration functions in `src/rules/mod.rs`:
+
+| Function | Purpose | Rules |
+|----------|---------|-------|
+| `v1_0_rules()` | Active by default (no flag) | 8 community-hit rules |
+| `all_rules()` | Behind `--unstable-rules` | All 65 rules |
+
+The engine checks `config.rules.is_disabled(rule_id)` before calling `check()`.
+
+### Categories
+
+```
+Flakiness (5)    - VITEST-FLK-*    → Non-deterministic test behavior
+Maintenance (18) - VITEST-MNT-*   → Code quality and test hygiene
+Structure (9)    - VITEST-STR-*   → Test organization and nesting
+Dependencies (7) - VITEST-DEP-*    → Mock and import isolation
+Validation (5)   - VITEST-VAL-*   → Correct test API usage
+Playwright (13)  - VITEST-PW-*    → Playwright E2E best practices
+No-* (10)        - VITEST-NO-*    → Banned patterns
+Prefer-* (10)    - VITEST-PREF-*  → Idiomatic matchers
+Require-* (3)    - VITEST-REQ-*   → Required patterns
+Consistency (3)  - VITEST-CON-*   → Consistent style
+```
+
+Total: 66 (8 stable + 58 unstable). Duplicate: 66 rules in `all_rules()` test.
+
+### AST-Based Analysis
+
+Rules do NOT re-parse source files. They consume `ParsedModule` which is populated by tree-sitter traversal in `TsParser`. Key data structures:
+
+- `TestBlock` — name, file_path, line, assertion_count, flags (uses_settimeout, has_conditional_logic, etc.)
+- `DescribeBlock` — name, depth, is_async, title metadata
+- `ParsedModule` — test_blocks, describe_blocks, imports, vi_mocks, hook_calls, runtime, playwright module data
+- `ModuleGraph` — resolved import edges for cross-file analysis (DEP rules)
+- `PlaywrightModule` — tracked calls, locator chains, axe usage
+
+### Rule Evaluation Flow
+
+```
+LintEngine::lint_paths()
+  └─ discover_files()                # WalkDir → test file filter
+  └─ parallel parse (rayon)          # TsParser::parse_file() per file
+  └─ ModuleGraph::new()              # Build import graph
+  └─ Group modules by config root
+  └─ For each (config, group):
+       └─ Create LintContext { config, all_modules }
+       └─ For each rule:
+            └─ skip if config.rules.is_disabled()
+            └─ skip if !rule.applies_to_runtime(module.runtime)
+            └─ rule.check(module, ctx, graph)
+            └─ apply severity override from config
+            └─ filter via SuppressionMap
+  └─ Sort violations by (file_path, line)
+```
+
+## Consequences
+
+- Adding a rule requires 5 mechanical steps: struct + impl, check() logic, registration in mod.rs, integration tests, field in models.rs if parser change needed.
+- Cross-file rules (DEP rules) access `ModuleGraph` and `LintContext.all_modules`.
+- Runtime gating prevents Playwright rules from firing on Vitest files and vice versa.
+- Suppression is post-hoc (filter step), not during parsing — ensures suppression comments don't affect other rules.

--- a/docs/superpowers/specs/2026-05-06-playwright-support-design.md
+++ b/docs/superpowers/specs/2026-05-06-playwright-support-design.md
@@ -1,0 +1,99 @@
+# Design: Playwright E2E Test Linting + Rule Hardening
+
+**Date:** 2026-05-06  
+**Status:** Approved  
+**Branch:** `feat/playwright-support`
+
+## Summary
+
+Add Playwright E2E test detection and 13 new `VITEST-PW-*` rules. Harden 7 existing rules based on real-world test smells from the Vidiom audit (issues A1-A7).
+
+## TestRuntime Detection
+
+`ParsedModule.runtime` is set during parsing based on imports:
+
+| Import Source | Runtime |
+|---------------|---------|
+| `@playwright/test` | `Playwright` |
+| `vitest` / any `vitest/...` | `Vitest` |
+| none of the above | `Unknown` |
+
+`Rule::applies_to_runtime(TestRuntime)` gates which rules fire. Default: `runtime != Playwright` (Vitest/Unknown only). Override to `true` for rules that apply to both (NoAssertion, FocusedTest, EmptyTest, NoIdenticalTitle).
+
+## Playwright Module Data
+
+`PlaywrightModule` struct tracked during parsing:
+
+```rust
+pub struct PlaywrightModule {
+    pub calls: Vec<PlaywrightCall>,          // Tracked call expressions
+    pub locator_chains: Vec<LocatorChain>,   // getByRole, locator, etc.
+    pub evaluate_inner_text: Vec<usize>,     // Lines with evaluate + innerText
+    pub uses_axe: bool,                      // injectAxe/checkA11y/AxeBuilder
+}
+```
+
+## Playwright Rules (13)
+
+### Easy AST-Match (PR 2)
+
+| Rule ID | Name | Detection |
+|---------|------|-----------|
+| VITEST-PW-001 | PwWaitForTimeoutRule | `page.waitForTimeout(...)` calls |
+| VITEST-PW-003 | PwXPathSelectorRule | `xpath=`, `//` strings, `.xpath()` calls |
+| VITEST-PW-004 | PwLocatorNthRule | `.nth(N)` positional locators |
+| VITEST-PW-005 | PwPageDollarRule | `page.$()` / `page.$$()` raw queries |
+| VITEST-PW-010 | PwArbitrarySleepRule | `await new Promise(r => setTimeout(r, N))` |
+
+### Selector-Based (PR 3)
+
+| Rule ID | Name | Detection |
+|---------|------|-----------|
+| VITEST-PW-002 | PwCssIdSelectorRule | CSS `#id` selectors |
+| VITEST-PW-006 | PwEvaluateInnerTextRule | `page.evaluate(() => document.body.innerText)` |
+| VITEST-PW-011 | PwHardCssClassChainRule | `.foo > .bar` descendant/child chains |
+
+`classify_selector` helper function with 30+ test fixtures classifies selector strings:
+
+- CSS ID (`#foo`, `input#name`)
+- CSS class (`.foo`, `div.bar`)
+- CSS attribute (`[data-testid=x]`, `[type=submit]`)
+- XPath (`//div`, `xpath=//button`)
+- Text (`text=Login`, `"Login"`)
+- Role (`getByRole`, role locator)
+- TestId (`getByTestId`, `[data-testid=...]`)
+- Semver (`>>`, `>`, `+` combinators)
+
+### File-Graph (PR 4)
+
+| Rule ID | Name | Detection |
+|---------|------|-----------|
+| VITEST-PW-009 | PwDuplicateSpecFileRule | Duplicate spec files (e.g., `foo.spec.ts` + `foo.spec 2.ts`) |
+
+### Heuristic (PR 5)
+
+| Rule ID | Name | Detection |
+|---------|------|-----------|
+| VITEST-PW-007 | PwTextAssertionOverRoleRule | Text-based `getByText`/`getByLabel` where `getByRole` works |
+| VITEST-PW-008 | PwTestIdOverSemanticRoleRule | `getByTestId` where semantic role locator exists |
+| VITEST-PW-012 | PwMissingWebFirstAssertionRule | Assertions without web-first matchers (`toHaveText`, `toBeVisible`) |
+| VITEST-PW-100 | PwMissingAxeScanRule | No `injectAxe`/`checkA11y`/`AxeBuilder` in Playwright files |
+
+## Rule Hardening (A1-A7)
+
+| Issue | Rule | Fix |
+|-------|------|-----|
+| A1 | VITEST-MNT-008 MissingMockCleanupRule | Also detect `global.X = vi.fn()` and `vi.stubGlobal(...)` as stubs requiring cleanup |
+| A2 | VITEST-DEP-001 BannedModuleMockRule | Add path-segment matching, integration-context boost, config knobs |
+| A3 | VITEST-MNT-009 WeakAssertionRule | Add extended matchers (`toBeCalled`, `toHaveReturned`, `toHaveProperty`) |
+| A4 | VITEST-MNT-010 ImplementationCoupledRule | Add `data-testid` negative-presence detection |
+| A5 | VITEST-FLK-001 TimeoutRule | Detect `Promise`-wrapped `setTimeout` (`new Promise(r => setTimeout(r, N))`) |
+| A6 | VITEST-MNT-007 FocusedTestRule | Fire on Playwright `test.only` / `describe.only` |
+| A7 | VITEST-PREF-003 PreferToHaveLengthRule | Extended patterns (`.length === 0`, `toEqual(length)` vs `toHaveLength`) |
+
+## Testing Strategy
+
+- Each PW rule: 1 positive + 1 negative integration test
+- `classify_selector`: 30+ unit test fixtures (one per selector class)
+- Hardenings: extend existing integration tests with new edge cases
+- Dogfood CI job: verifies linter detects all smells on known-bad fixtures


### PR DESCRIPTION
## Summary

- Create `docs/architecture/` with 5 formal ADRs covering the project's key architectural decisions
- Add missing Playwright support design spec in `docs/superpowers/specs/`

## ADRs

1. **ADR-001**: Project Architecture — Rust CLI tool, single-crate Cargo workspace, two-phase lint pipeline, Rule trait, runtime gating, inline suppression, walk-up config
2. **ADR-002**: Toolchain — cargo (edition 2021), rustfmt, clippy (nightly pedantic), cargo-llvm-cov, cargo-audit, cargo-mutants, cargo-dist, structurelint
3. **ADR-003**: Quality Gates — PR gate (fmt/clippy/test/coverage/audit/dogfood/structure → required-checks), merge gate (+SonarCloud), branch protection rules, self-hosted macOS runner
4. **ADR-004**: Testing Strategy — unit (inline #[cfg(test)]), integration (tempfile fixtures, 100+ tests), corpus regression, mutation (cargo-mutants, ≥75%), benchmark (criterion), coverage (≥90% lines, SonarCloud key Jonathangadeaharder_vitest-linter)
5. **ADR-005**: Lint Rule Architecture — Rule trait, v1_0_rules()/all_rules() registry, 10 categories (66 rules total), AST-based analysis with ParsedModule consumption, rule evaluation flow diagram, severity override + suppression filtering

## Missing Spec Added

- **2026-05-06-playwright-support-design.md**: TestRuntime detection, PlaywrightModule data model, 13 PW rules (4 easy AST-match, 3 selector-based, 1 file-graph, 4 heuristic), A1-A7 rule hardening, selector classifier helper with 30+ fixtures
