### PR TITLE
fix: exclude test fixtures from SonarCloud analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,3 +4,4 @@ sonar.sources=src
 sonar.tests=tests
 sonar.sourceEncoding=UTF-8
 sonar.rust.lcov.reportPaths=coverage.lcov
+sonar.exclusions=tests/fixtures/**


### PR DESCRIPTION
Adds tests/fixtures to sonar exclusions - these are intentional test fixtures with .only() patterns.