### PR TITLE
fix: add SonarCloud test exclusions for fixtures

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,3 +5,4 @@ sonar.tests=tests
 sonar.sourceEncoding=UTF-8
 sonar.rust.lcov.reportPaths=coverage.lcov
 sonar.exclusions=tests/fixtures/**
+sonar.test.exclusions=tests/fixtures/**


### PR DESCRIPTION
sonar.exclusions doesn't apply to test files - need sonar.test.exclusions to exclude test fixtures from analysis.