### PR TITLE
refactor: reduce cognitive complexity in core modules

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -133,26 +133,7 @@ impl Config {
             Self::default()
         };
 
-        // Check for package.json override
-        if let Some(pkg_dir) = find_package_json_dir(start) {
-            let pkg_path = pkg_dir.join("package.json");
-            if let Ok(pkg_text) = std::fs::read_to_string(&pkg_path) {
-                if let Ok(pkg) = serde_json::from_str::<serde_json::Value>(&pkg_text) {
-                    if let Some(vl_config) = pkg.get("vitest-linter") {
-                        if let Some(select) = vl_config.get("select").and_then(|s| s.as_object()) {
-                            for (key, val) in select {
-                                if let Some(severity) = val.as_str() {
-                                    config
-                                        .rules
-                                        .select
-                                        .insert(key.clone(), severity.to_string());
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        merge_package_json_overrides(&mut config, start);
 
         Ok(config)
     }
@@ -385,6 +366,35 @@ fn find_package_json_dir(start: &Path) -> Option<PathBuf> {
         cur = dir.parent().map(Path::to_path_buf);
     }
     None
+}
+
+/// Merge `vitest-linter` config from `package.json` into the config struct.
+/// Uses early returns to keep cognitive complexity low.
+fn merge_package_json_overrides(config: &mut Config, start: &Path) {
+    let pkg_dir = match find_package_json_dir(start) {
+        Some(d) => d,
+        None => return,
+    };
+    let pkg_path = pkg_dir.join("package.json");
+    let pkg_text = match std::fs::read_to_string(&pkg_path) {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+    let pkg = match serde_json::from_str::<serde_json::Value>(&pkg_text) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let Some(vl_config) = pkg.get("vitest-linter") else {
+        return;
+    };
+    let Some(select) = vl_config.get("select").and_then(|s| s.as_object()) else {
+        return;
+    };
+    for (key, val) in select {
+        if let Some(severity) = val.as_str() {
+            config.rules.select.insert(key.clone(), severity.to_string());
+        }
+    }
 }
 
 /// Match a `vi.mock(<source>)` source string against the banlist. The check

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -7,7 +7,7 @@ use walkdir::WalkDir;
 use crate::config::{Config, TsConfig};
 use crate::models::{Diagnostic, ModuleGraph, ParsedModule, Violation};
 use crate::parser::TsParser;
-use crate::rules::{all_rules, v1_0_rules, LintContext};
+use crate::rules::{all_rules, v1_0_rules, LintContext, Rule};
 use crate::suppression::SuppressionMap;
 
 /// Top-level linting engine that coordinates file discovery, parsing, rule
@@ -79,6 +79,34 @@ impl LintEngine {
         let files = Self::discover_files(paths);
 
         // Phase 1: Parse test files in parallel
+        let (modules, sources) = self.parse_files(&files);
+
+        // Discover source modules referenced by imports
+        let source_modules = Self::discover_source_modules(&modules);
+
+        // Build module graph
+        let graph = ModuleGraph::new(&modules, &source_modules);
+
+        // Group modules by their resolved config root
+        let groups = Self::group_by_config(&modules);
+
+        let rules = if self.unstable_rules {
+            all_rules()
+        } else {
+            v1_0_rules()
+        };
+
+        // Pre-parse suppression maps once per file
+        let suppressions = pre_parse_suppressions(&sources);
+
+        // Phase 2: Rule evaluation with shared ModuleGraph
+        let violations = evaluate_rules(&groups, &rules, &modules, &suppressions, &graph);
+
+        Ok((violations, Vec::new()))
+    }
+
+    /// Phase 1: parse test files in parallel, returning modules and their source text.
+    fn parse_files(&self, files: &[PathBuf]) -> (Vec<ParsedModule>, Vec<String>) {
         let parsed: Vec<_> = files
             .par_iter()
             .filter_map(|file| {
@@ -94,14 +122,13 @@ impl LintEngine {
             modules.push(module);
             sources.push(source);
         }
+        (modules, sources)
+    }
 
-        // Discover source modules referenced by imports
-        let source_modules = Self::discover_source_modules(&modules);
-
-        // Build module graph
-        let graph = ModuleGraph::new(&modules, &source_modules);
-
-        // Group modules by their resolved config root
+    /// Group modules by their resolved config root directory.
+    fn group_by_config(
+        modules: &[ParsedModule],
+    ) -> HashMap<PathBuf, (Config, Vec<usize>)> {
         let mut groups: HashMap<PathBuf, (Config, Vec<usize>)> = HashMap::new();
         for (idx, module) in modules.iter().enumerate() {
             let config_root = Self::resolve_config_root(&module.file_path);
@@ -111,63 +138,7 @@ impl LintEngine {
             });
             entry.1.push(idx);
         }
-
-        let rules = if self.unstable_rules {
-            all_rules()
-        } else {
-            v1_0_rules()
-        };
-        let mut violations = Vec::new();
-        let diagnostics = Vec::new();
-
-        // Pre-parse suppression maps once per file
-        let suppressions: Vec<SuppressionMap> =
-            sources.iter().map(|s| SuppressionMap::parse(s)).collect();
-
-        // Phase 2: Rule evaluation with shared ModuleGraph
-        for (config, indices) in groups.values() {
-            let group_modules: Vec<ParsedModule> =
-                indices.iter().map(|i| modules[*i].clone()).collect();
-            let ctx = LintContext {
-                config,
-                all_modules: &group_modules,
-            };
-            for rule in &rules {
-                if config.rules.is_disabled(rule.id()) {
-                    continue;
-                }
-                for (local_idx, module) in group_modules.iter().enumerate() {
-                    if !rule.applies_to_runtime(module.runtime) {
-                        continue;
-                    }
-                    let global_idx = indices[local_idx];
-                    let mut v = rule.check(module, &ctx, &graph);
-                    if let Some(override_sev) = config.rules.severity_override(rule.id()) {
-                        for violation in &mut v {
-                            violation.severity = match override_sev.to_ascii_lowercase().as_str() {
-                                "error" => crate::models::Severity::Error,
-                                "warning" => crate::models::Severity::Warning,
-                                "info" => crate::models::Severity::Info,
-                                _ => violation.severity,
-                            };
-                        }
-                    }
-                    let suppression = &suppressions[global_idx];
-                    v.retain(|violation| {
-                        !suppression.is_suppressed(violation.line, &violation.rule_id)
-                    });
-                    violations.append(&mut v);
-                }
-            }
-        }
-
-        violations.sort_by(|a, b| {
-            a.file_path
-                .cmp(&b.file_path)
-                .then_with(|| a.line.cmp(&b.line))
-        });
-
-        Ok((violations, diagnostics))
+        groups
     }
 
     /// Walk up from the module's path to find the directory containing
@@ -229,47 +200,10 @@ impl LintEngine {
     /// Discover source modules referenced by imports in test files.
     /// Skips node_modules and external packages.
     fn discover_source_modules(modules: &[ParsedModule]) -> Vec<ParsedModule> {
-        let mut source_files = Vec::new();
-
-        for module in modules {
-            // Collect sources from both imports and vi.mock() calls
-            let mut sources: Vec<&str> = Vec::new();
-            for imp in &module.imports_parsed {
-                sources.push(&imp.source);
-            }
-            for mock in &module.vi_mocks {
-                if !sources.contains(&mock.source.as_str()) {
-                    sources.push(&mock.source);
-                }
-            }
-
-            for source in &sources {
-                // Skip external packages
-                if !source.starts_with('.') && !source.starts_with('/') {
-                    continue;
-                }
-                // Try to resolve the import to a file
-                if let Some(parent) = module.file_path.parent() {
-                    let base = parent.join(source);
-                    let exts = [".ts", ".tsx", ".js", ".jsx"];
-                    for ext in &exts {
-                        let candidate = base.with_extension(ext.strip_prefix('.').unwrap());
-                        if candidate.is_file() {
-                            source_files.push(candidate);
-                            break;
-                        }
-                    }
-                    // Try index files
-                    for name in &["index.ts", "index.tsx", "index.js", "index.jsx"] {
-                        let candidate = base.join(name);
-                        if candidate.is_file() {
-                            source_files.push(candidate);
-                            break;
-                        }
-                    }
-                }
-            }
-        }
+        let mut source_files: Vec<PathBuf> = modules
+            .iter()
+            .flat_map(collect_source_paths)
+            .collect();
 
         source_files.sort();
         source_files.dedup();
@@ -286,6 +220,131 @@ impl LintEngine {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Phase 2: rule evaluation
+// ---------------------------------------------------------------------------
+
+/// Evaluate all rules against grouped modules, applying severity overrides and
+/// suppression filtering. Returns sorted violations.
+fn evaluate_rules(
+    groups: &HashMap<PathBuf, (Config, Vec<usize>)>,
+    rules: &[Box<dyn Rule>],
+    modules: &[ParsedModule],
+    suppressions: &[SuppressionMap],
+    graph: &ModuleGraph,
+) -> Vec<Violation> {
+    let mut violations = Vec::new();
+    for (config, indices) in groups.values() {
+        let group_modules: Vec<ParsedModule> =
+            indices.iter().map(|i| modules[*i].clone()).collect();
+        let ctx = LintContext {
+            config,
+            all_modules: &group_modules,
+        };
+        for rule in rules {
+            if config.rules.is_disabled(rule.id()) {
+                continue;
+            }
+            for (local_idx, module) in group_modules.iter().enumerate() {
+                if !rule.applies_to_runtime(module.runtime) {
+                    continue;
+                }
+                let global_idx = indices[local_idx];
+                let mut v = rule.check(module, &ctx, graph);
+                if let Some(override_sev) = config.rules.severity_override(rule.id()) {
+                    for violation in &mut v {
+                        violation.severity = match override_sev.to_ascii_lowercase().as_str() {
+                            "error" => crate::models::Severity::Error,
+                            "warning" => crate::models::Severity::Warning,
+                            "info" => crate::models::Severity::Info,
+                            _ => violation.severity,
+                        };
+                    }
+                }
+                let suppression = &suppressions[global_idx];
+                v.retain(|violation| {
+                    !suppression.is_suppressed(violation.line, &violation.rule_id)
+                });
+                violations.append(&mut v);
+            }
+        }
+    }
+
+    violations.sort_by(|a, b| {
+        a.file_path
+            .cmp(&b.file_path)
+            .then_with(|| a.line.cmp(&b.line))
+    });
+    violations
+}
+
+// ---------------------------------------------------------------------------
+// Suppression helpers
+// ---------------------------------------------------------------------------
+
+/// Pre-parse suppression comment maps from source text.
+fn pre_parse_suppressions(sources: &[String]) -> Vec<SuppressionMap> {
+    sources.iter().map(|s| SuppressionMap::parse(s)).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Source module discovery helpers
+// ---------------------------------------------------------------------------
+
+/// Collect all resolved source file paths referenced by a module's imports and
+/// vi.mock() calls, skipping external packages.
+fn collect_source_paths(module: &ParsedModule) -> Vec<PathBuf> {
+    let mut sources: Vec<&str> = Vec::new();
+    for imp in &module.imports_parsed {
+        sources.push(&imp.source);
+    }
+    for mock in &module.vi_mocks {
+        if !sources.contains(&mock.source.as_str()) {
+            sources.push(&mock.source);
+        }
+    }
+
+    sources
+        .iter()
+        .filter_map(|source| resolve_source_path(module, source))
+        .collect()
+}
+
+/// Resolve a single import source string to an absolute file path.
+///
+/// Attempts extension-less resolution, then index file resolution, within the
+/// module's parent directory. Returns `None` for external packages or
+/// unresolvable paths.
+fn resolve_source_path(module: &ParsedModule, source: &str) -> Option<PathBuf> {
+    // Skip external packages
+    if !source.starts_with('.') && !source.starts_with('/') {
+        return None;
+    }
+    let parent = module.file_path.parent()?;
+    let base = parent.join(source);
+    let exts = [".ts", ".tsx", ".js", ".jsx"];
+
+    for ext in &exts {
+        let candidate = base.with_extension(ext.strip_prefix('.').unwrap());
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    for name in &["index.ts", "index.tsx", "index.js", "index.jsx"] {
+        let candidate = base.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 fn is_test_file(name: &str) -> bool {
     let name = name.to_ascii_lowercase();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use colored::Colorize;
 
 use engine::LintEngine;
-use models::Severity;
+use models::{Diagnostic, Severity};
 
 fn get_changed_files(base: &str) -> Result<Vec<PathBuf>> {
     let output = std::process::Command::new("git")
@@ -78,79 +78,97 @@ pub fn run_cli(
     let engine = LintEngine::new(unstable_rules)?;
     let (violations, diagnostics) = engine.lint_paths(&effective_paths)?;
 
-    if format == "json" {
-        let json = serde_json::to_string_pretty(&violations)?;
-        match output {
-            Some(path) => fs::write(path, json)?,
-            None => println!("{json}"),
-        }
-    } else if format == "sarif" {
-        let sarif = build_sarif(&violations);
-        let json = serde_json::to_string_pretty(&sarif)?;
-        match output {
-            Some(path) => fs::write(path, json)?,
-            None => println!("{json}"),
-        }
-    } else {
-        let mut out: Box<dyn Write> = match output {
-            Some(path) => Box::new(fs::File::create(path)?),
-            None => Box::new(std::io::stdout()),
-        };
-
-        for diag in &diagnostics {
-            writeln!(out, "{}: {}", "Info".blue().bold(), diag.message)?;
-        }
-
-        if violations.is_empty() {
-            writeln!(out, "{} No test smells detected.", "\u{2713}".green())?;
-        } else {
-            for v in &violations {
-                let severity_str = match v.severity {
-                    Severity::Error => "Error".red().bold().to_string(),
-                    Severity::Warning => "Warning".yellow().bold().to_string(),
-                    Severity::Info => "Info".blue().bold().to_string(),
-                };
-                writeln!(
-                    out,
-                    "{}: {} in {}:{}",
-                    severity_str,
-                    v.rule_id.cyan(),
-                    v.file_path.display().to_string().white(),
-                    v.line
-                )?;
-                writeln!(out, "  {}", v.message)?;
-                if let Some(ref suggestion) = v.suggestion {
-                    writeln!(out, "  {} {}", "Suggestion:".dimmed(), suggestion.dimmed())?;
-                }
-                writeln!(out)?;
-            }
-
-            let errors = violations
-                .iter()
-                .filter(|v| v.severity == Severity::Error)
-                .count();
-            let warnings = violations
-                .iter()
-                .filter(|v| v.severity == Severity::Warning)
-                .count();
-            let infos = violations
-                .iter()
-                .filter(|v| v.severity == Severity::Info)
-                .count();
-
-            writeln!(
-                out,
-                "Found {} violation(s): {} error(s), {} warning(s), {} info",
-                violations.len(),
-                errors,
-                warnings,
-                infos
-            )?;
-        }
+    match format {
+        "json" => output_json(&violations, output)?,
+        "sarif" => output_sarif(&violations, output)?,
+        _ => output_human(&violations, &diagnostics, output)?,
     }
 
     let has_errors = violations.iter().any(|v| v.severity == Severity::Error);
     Ok(has_errors)
+}
+
+fn output_json(violations: &[models::Violation], output: Option<&Path>) -> Result<()> {
+    let json = serde_json::to_string_pretty(violations)?;
+    match output {
+        Some(path) => fs::write(path, json)?,
+        None => println!("{json}"),
+    }
+    Ok(())
+}
+
+fn output_sarif(violations: &[models::Violation], output: Option<&Path>) -> Result<()> {
+    let sarif = build_sarif(violations);
+    let json = serde_json::to_string_pretty(&sarif)?;
+    match output {
+        Some(path) => fs::write(path, json)?,
+        None => println!("{json}"),
+    }
+    Ok(())
+}
+
+fn output_human(
+    violations: &[models::Violation],
+    diagnostics: &[Diagnostic],
+    output: Option<&Path>,
+) -> Result<()> {
+    let mut out: Box<dyn Write> = match output {
+        Some(path) => Box::new(fs::File::create(path)?),
+        None => Box::new(std::io::stdout()),
+    };
+
+    for diag in diagnostics {
+        writeln!(out, "{}: {}", "Info".blue().bold(), diag.message)?;
+    }
+
+    if violations.is_empty() {
+        writeln!(out, "{} No test smells detected.", "\u{2713}".green())?;
+    } else {
+        for v in violations {
+            let severity_str = match v.severity {
+                Severity::Error => "Error".red().bold().to_string(),
+                Severity::Warning => "Warning".yellow().bold().to_string(),
+                Severity::Info => "Info".blue().bold().to_string(),
+            };
+            writeln!(
+                out,
+                "{}: {} in {}:{}",
+                severity_str,
+                v.rule_id.cyan(),
+                v.file_path.display().to_string().white(),
+                v.line
+            )?;
+            writeln!(out, "  {}", v.message)?;
+            if let Some(ref suggestion) = v.suggestion {
+                writeln!(out, "  {} {}", "Suggestion:".dimmed(), suggestion.dimmed())?;
+            }
+            writeln!(out)?;
+        }
+
+        let errors = violations
+            .iter()
+            .filter(|v| v.severity == Severity::Error)
+            .count();
+        let warnings = violations
+            .iter()
+            .filter(|v| v.severity == Severity::Warning)
+            .count();
+        let infos = violations
+            .iter()
+            .filter(|v| v.severity == Severity::Info)
+            .count();
+
+        writeln!(
+            out,
+            "Found {} violation(s): {} error(s), {} warning(s), {} info",
+            violations.len(),
+            errors,
+            warnings,
+            infos
+        )?;
+    }
+
+    Ok(())
 }
 
 fn build_sarif(violations: &[models::Violation]) -> serde_json::Value {

--- a/src/models.rs
+++ b/src/models.rs
@@ -221,52 +221,10 @@ impl ModuleGraph {
     #[must_use]
     pub fn new(test_modules: &[ParsedModule], source_modules: &[ParsedModule]) -> Self {
         let mut modules = HashMap::new();
-        let mut edges = HashMap::new();
-
-        // Add all modules to the graph
         for module in test_modules.iter().chain(source_modules.iter()) {
             modules.insert(module.file_path.clone(), module.clone());
-            edges.insert(module.file_path.clone(), Vec::new());
         }
-
-        // Build edges from imports
-        for module in test_modules.iter().chain(source_modules.iter()) {
-            for imp in &module.imports_parsed {
-                // Try to resolve relative imports
-                if imp.source.starts_with('.') || imp.source.starts_with('/') {
-                    if let Some(parent) = module.file_path.parent() {
-                        let base = parent.join(&imp.source);
-                        let exts = [".ts", ".tsx", ".js", ".jsx"];
-                        let mut resolved = false;
-                        for ext in &exts {
-                            let candidate = base.with_extension(ext.strip_prefix('.').unwrap());
-                            if modules.contains_key(&candidate) {
-                                edges
-                                    .entry(module.file_path.clone())
-                                    .or_default()
-                                    .push(candidate);
-                                resolved = true;
-                                break;
-                            }
-                        }
-                        // Check for index files if direct file not found
-                        if !resolved {
-                            for ext in &exts {
-                                let candidate = base.join(format!("index{}", ext));
-                                if modules.contains_key(&candidate) {
-                                    edges
-                                        .entry(module.file_path.clone())
-                                        .or_default()
-                                        .push(candidate);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
+        let edges = build_edges(&modules, test_modules, source_modules);
         Self { modules, edges }
     }
 
@@ -288,6 +246,61 @@ impl ModuleGraph {
             })
             .unwrap_or_default()
     }
+}
+
+/// Resolve a relative import to an absolute module path, if the module exists.
+fn resolve_import_edge(
+    module: &ParsedModule,
+    imp: &ImportEntry,
+    modules: &HashMap<PathBuf, ParsedModule>,
+) -> Option<PathBuf> {
+    // Skip non-relative imports (bare specifiers like "vitest", "lodash")
+    if !imp.source.starts_with('.') && !imp.source.starts_with('/') {
+        return None;
+    }
+
+    let parent = module.file_path.parent()?;
+    let base = parent.join(&imp.source);
+    let exts = [".ts", ".tsx", ".js", ".jsx"];
+
+    // Try direct file match (e.g., "./foo" → "./foo.ts")
+    for ext in &exts {
+        let candidate = base.with_extension(ext.strip_prefix('.').unwrap());
+        if modules.contains_key(&candidate) {
+            return Some(candidate);
+        }
+    }
+
+    // Try index file match (e.g., "./dir" → "./dir/index.ts")
+    for ext in &exts {
+        let candidate = base.join(format!("index{}", ext));
+        if modules.contains_key(&candidate) {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+/// Build edges from import statements for all modules.
+fn build_edges(
+    modules: &HashMap<PathBuf, ParsedModule>,
+    test_modules: &[ParsedModule],
+    source_modules: &[ParsedModule],
+) -> HashMap<PathBuf, Vec<PathBuf>> {
+    let mut edges: HashMap<PathBuf, Vec<PathBuf>> = HashMap::new();
+
+    for module in test_modules.iter().chain(source_modules.iter()) {
+        let file_path = &module.file_path;
+        edges.entry(file_path.clone()).or_default();
+        for imp in &module.imports_parsed {
+            if let Some(resolved) = resolve_import_edge(module, imp, modules) {
+                edges.entry(file_path.clone()).or_default().push(resolved);
+            }
+        }
+    }
+
+    edges
 }
 
 #[derive(Debug, Clone)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -100,29 +100,7 @@ impl TsParser {
             };
             match child.kind() {
                 "import_statement" => {
-                    let text = child.utf8_text(source.as_bytes()).unwrap_or("").to_string();
-                    ctx.imports.push(text);
-                    if let Some(entry) = Self::parse_import(child, source) {
-                        if entry.source == "node:test" {
-                            ctx.imports_node_test = true;
-                        }
-                        if entry.source == "@playwright/test" {
-                            ctx.runtime = TestRuntime::Playwright;
-                            ctx.playwright_module = Some(PlaywrightModule::default());
-                        } else if entry.source.starts_with("vitest")
-                            && ctx.runtime == TestRuntime::Unknown
-                        {
-                            ctx.runtime = TestRuntime::Vitest;
-                        }
-                        if entry.source == "axe-playwright"
-                            || entry.source == "@axe-core/playwright"
-                        {
-                            if let Some(ref mut pw) = ctx.playwright_module {
-                                pw.uses_axe = true;
-                            }
-                        }
-                        ctx.imports_parsed.push(entry);
-                    }
+                    Self::collect_import_statement(child, source, ctx);
                 }
                 "call_expression" => {
                     Self::handle_call(child, source, path, describe_depth, scope, ctx);
@@ -140,6 +118,29 @@ impl TsParser {
                 }
             }
         }
+    }
+
+    fn collect_import_statement(child: Node, source: &str, ctx: &mut Context) {
+        let text = child.utf8_text(source.as_bytes()).unwrap_or("").to_string();
+        ctx.imports.push(text);
+        let Some(entry) = Self::parse_import(child, source) else {
+            return;
+        };
+        if entry.source == "node:test" {
+            ctx.imports_node_test = true;
+        }
+        if entry.source == "@playwright/test" {
+            ctx.runtime = TestRuntime::Playwright;
+            ctx.playwright_module = Some(PlaywrightModule::default());
+        } else if entry.source.starts_with("vitest") && ctx.runtime == TestRuntime::Unknown {
+            ctx.runtime = TestRuntime::Vitest;
+        }
+        if entry.source == "axe-playwright" || entry.source == "@axe-core/playwright" {
+            if let Some(ref mut pw) = ctx.playwright_module {
+                pw.uses_axe = true;
+            }
+        }
+        ctx.imports_parsed.push(entry);
     }
 
     fn collect_global_stub_assignment(node: &Node, source: &str, ctx: &mut Context) {
@@ -171,32 +172,35 @@ impl TsParser {
             let Some(child) = node.named_child(i) else {
                 continue;
             };
-            if child.kind() == "variable_declarator" {
-                let text = child.utf8_text(source.as_bytes()).unwrap_or("");
-                if text.contains("vi.fn()") || text.contains("vi.fn(") {
-                    if let Some(name_node) = child.child_by_field_name("name") {
-                        let name = name_node
-                            .utf8_text(source.as_bytes())
-                            .unwrap_or("")
-                            .to_string();
-                        if name.starts_with("global.") || name.starts_with("globalThis.") {
-                            let target_name = name
-                                .strip_prefix("global.")
-                                .or_else(|| name.strip_prefix("globalThis."))
-                                .unwrap_or(&name)
-                                .to_string();
-                            ctx.global_stubs.push(GlobalStub {
-                                target: target_name,
-                                line: node.start_position().row + 1,
-                            });
-                        }
-                    }
-                }
+            if child.kind() != "variable_declarator" {
+                continue;
             }
+            let text = child.utf8_text(source.as_bytes()).unwrap_or("");
+            if !text.contains("vi.fn()") && !text.contains("vi.fn(") {
+                continue;
+            }
+            let Some(name_node) = child.child_by_field_name("name") else {
+                continue;
+            };
+            let name = name_node
+                .utf8_text(source.as_bytes())
+                .unwrap_or("")
+                .to_string();
+            if !name.starts_with("global.") && !name.starts_with("globalThis.") {
+                continue;
+            }
+            let target_name = name
+                .strip_prefix("global.")
+                .or_else(|| name.strip_prefix("globalThis."))
+                .unwrap_or(&name)
+                .to_string();
+            ctx.global_stubs.push(GlobalStub {
+                target: target_name,
+                line: node.start_position().row + 1,
+            });
         }
     }
 
-    #[allow(clippy::too_many_lines)]
     fn handle_call(
         node: Node,
         source: &str,
@@ -216,117 +220,178 @@ impl TsParser {
             .unwrap_or("")
             .to_string();
 
-        // Track expect() calls at module level (outside test blocks)
+        Self::track_expect_outside_test(&func_name, scope, node, ctx);
+        Self::track_snapshot_calls(&full_callee, node, source, ctx);
+        Self::track_vi_mock(&full_callee, node, source, scope, ctx);
+        Self::track_vi_stub_global(&full_callee, node, source, ctx);
+        Self::track_pw_runtime(ctx, &full_callee, node, source);
+
+        Self::dispatch_call(
+            &func_name,
+            &full_callee,
+            is_skip,
+            is_only,
+            node,
+            source,
+            path,
+            describe_depth,
+            scope,
+            ctx,
+        );
+    }
+
+    fn track_expect_outside_test(func_name: &str, scope: MockScope, node: Node, ctx: &mut Context) {
         if scope == MockScope::Module && func_name == "expect" {
             ctx.expects_outside_tests.push(ExpectOutsideTest {
                 line: node.start_position().row + 1,
             });
         }
+    }
 
-        // Detect snapshot matcher calls with inline content
-        if full_callee.ends_with(".toMatchInlineSnapshot")
-            || full_callee.ends_with(".toMatchSnapshot")
+    fn track_snapshot_calls(full_callee: &str, node: Node, source: &str, ctx: &mut Context) {
+        if !full_callee.ends_with(".toMatchInlineSnapshot")
+            && !full_callee.ends_with(".toMatchSnapshot")
         {
-            if let Some(args) = node.child_by_field_name("arguments") {
-                if args.named_child_count() > 0 {
-                    if let Some(first) = args.named_child(0) {
-                        if first.kind() == "string" || first.kind() == "template_string" {
-                            let content = first.utf8_text(source.as_bytes()).unwrap_or("");
-                            ctx.snapshot_sizes.push(SnapshotSize {
-                                line: first.start_position().row + 1,
-                                size: content.lines().count(),
-                            });
-                        }
-                    }
-                }
-            }
+            return;
         }
-
-        // vi.mock(...) — module-scope hoisted mock when at module scope, but we
-        // record it with the actual lexical scope so rules can decide.
-        if full_callee == "vi.mock" {
-            if let Some(entry) = Self::extract_vi_mock(node, source, scope) {
-                ctx.vi_mocks.push(entry);
-            }
+        let Some(args) = node.child_by_field_name("arguments") else {
+            return;
+        };
+        let Some(first) = args.named_child(0) else {
+            return;
+        };
+        if first.kind() == "string" || first.kind() == "template_string" {
+            let content = first.utf8_text(source.as_bytes()).unwrap_or("");
+            ctx.snapshot_sizes.push(SnapshotSize {
+                line: first.start_position().row + 1,
+                size: content.lines().count(),
+            });
         }
+    }
 
-        // vi.stubGlobal(name, ...) — records global stub without cleanup
-        if full_callee == "vi.stubGlobal" {
-            if let Some(args) = node.child_by_field_name("arguments") {
-                if let Some(first) = args.named_child(0) {
-                    if let Some(target) = Self::string_value(first, source) {
-                        ctx.global_stubs.push(GlobalStub {
-                            target,
-                            line: node.start_position().row + 1,
-                        });
-                    }
-                }
-            }
+    fn track_vi_mock(full_callee: &str, node: Node, source: &str, scope: MockScope, ctx: &mut Context) {
+        if full_callee != "vi.mock" {
+            return;
         }
+        if let Some(entry) = Self::extract_vi_mock(node, source, scope) {
+            ctx.vi_mocks.push(entry);
+        }
+    }
 
-        // Playwright-specific call tracking
+    fn track_vi_stub_global(full_callee: &str, node: Node, source: &str, ctx: &mut Context) {
+        if full_callee != "vi.stubGlobal" {
+            return;
+        }
+        let Some(args) = node.child_by_field_name("arguments") else {
+            return;
+        };
+        let Some(first) = args.named_child(0) else {
+            return;
+        };
+        if let Some(target) = Self::string_value(first, source) {
+            ctx.global_stubs.push(GlobalStub {
+                target,
+                line: node.start_position().row + 1,
+            });
+        }
+    }
+
+    fn track_pw_runtime(ctx: &mut Context, full_callee: &str, node: Node, source: &str) {
         if ctx.runtime == TestRuntime::Playwright {
-            Self::track_playwright_call(&full_callee, node, source, ctx);
+            Self::track_playwright_call(full_callee, node, source, ctx);
         }
+    }
 
-        match func_name.as_str() {
+    #[allow(clippy::too_many_arguments)]
+    fn dispatch_call(
+        func_name: &str,
+        full_callee: &str,
+        is_skip: bool,
+        is_only: bool,
+        node: Node,
+        source: &str,
+        path: &Path,
+        describe_depth: usize,
+        scope: MockScope,
+        ctx: &mut Context,
+    ) {
+        match func_name {
             "test" | "it" | "fit" | "xit" => {
-                // Playwright: test.describe / test.describe.only are describe blocks
-                if full_callee.starts_with("test.describe") {
-                    Self::add_describe_block(
-                        node,
-                        source,
-                        path,
-                        describe_depth,
-                        is_only,
-                        scope,
-                        ctx,
-                    );
-                } else {
-                    let uses_fit_or_xit =
-                        full_callee.starts_with("fit") || full_callee.starts_with("xit");
-                    if let Some(tb) = Self::extract_test(
-                        node,
-                        source,
-                        path,
-                        describe_depth,
-                        is_skip,
-                        is_only,
-                        uses_fit_or_xit,
-                    ) {
-                        ctx.test_blocks.push(tb);
-                    }
-                    if let Some(body) = Self::callback_body(node) {
-                        Self::collect(body, source, path, describe_depth, MockScope::Test, ctx);
-                    }
-                }
+                Self::dispatch_test_call(
+                    full_callee, is_skip, is_only, node, source, path, describe_depth, scope, ctx,
+                );
             }
             "describe" | "fdescribe" | "xdescribe" => {
                 Self::add_describe_block(node, source, path, describe_depth, is_only, scope, ctx);
             }
             "beforeEach" | "afterEach" | "beforeAll" | "afterAll" => {
-                let kind = match func_name.as_str() {
-                    "beforeEach" => HookKind::BeforeEach,
-                    "afterEach" => HookKind::AfterEach,
-                    "beforeAll" => HookKind::BeforeAll,
-                    "afterAll" => HookKind::AfterAll,
-                    _ => unreachable!(),
-                };
-                let mut vi_calls = Vec::new();
-                if let Some(body) = Self::single_callback_body(node) {
-                    Self::collect_vi_calls(body, source, &mut vi_calls);
-                    Self::collect(body, source, path, describe_depth, MockScope::Hook, ctx);
-                }
-                ctx.hook_calls.push(HookCall {
-                    kind,
-                    line: node.start_position().row + 1,
-                    vi_calls,
-                });
+                Self::dispatch_hook_call(func_name, node, source, path, describe_depth, ctx);
             }
             _ => {
                 Self::collect(node, source, path, describe_depth, scope, ctx);
             }
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn dispatch_test_call(
+        full_callee: &str,
+        is_skip: bool,
+        is_only: bool,
+        node: Node,
+        source: &str,
+        path: &Path,
+        describe_depth: usize,
+        scope: MockScope,
+        ctx: &mut Context,
+    ) {
+        if full_callee.starts_with("test.describe") {
+            Self::add_describe_block(node, source, path, describe_depth, is_only, scope, ctx);
+        } else {
+            let uses_fit_or_xit =
+                full_callee.starts_with("fit") || full_callee.starts_with("xit");
+            if let Some(tb) = Self::extract_test(
+                node,
+                source,
+                path,
+                describe_depth,
+                is_skip,
+                is_only,
+                uses_fit_or_xit,
+            ) {
+                ctx.test_blocks.push(tb);
+            }
+            if let Some(body) = Self::callback_body(node) {
+                Self::collect(body, source, path, describe_depth, MockScope::Test, ctx);
+            }
+        }
+    }
+
+    fn dispatch_hook_call(
+        func_name: &str,
+        node: Node,
+        source: &str,
+        path: &Path,
+        describe_depth: usize,
+        ctx: &mut Context,
+    ) {
+        let kind = match func_name {
+            "beforeEach" => HookKind::BeforeEach,
+            "afterEach" => HookKind::AfterEach,
+            "beforeAll" => HookKind::BeforeAll,
+            "afterAll" => HookKind::AfterAll,
+            _ => unreachable!(),
+        };
+        let mut vi_calls = Vec::new();
+        if let Some(body) = Self::single_callback_body(node) {
+            Self::collect_vi_calls(body, source, &mut vi_calls);
+            Self::collect(body, source, path, describe_depth, MockScope::Hook, ctx);
+        }
+        ctx.hook_calls.push(HookCall {
+            kind,
+            line: node.start_position().row + 1,
+            vi_calls,
+        });
     }
 
     fn collect_vi_calls(node: Node, source: &str, out: &mut Vec<String>) {
@@ -380,78 +445,108 @@ impl TsParser {
 
         // Check for `export { a, b }` (re-exports or named exports)
         for i in 0..node.named_child_count() {
-            if let Some(child) = node.named_child(i) {
-                match child.kind() {
-                    "export_clause" => {
-                        for j in 0..child.named_child_count() {
-                            if let Some(spec) = child.named_child(j) {
-                                if spec.kind() == "export_specifier" {
-                                    let name = spec
-                                        .child_by_field_name("name")
-                                        .and_then(|n| n.utf8_text(source.as_bytes()).ok())
-                                        .unwrap_or("")
-                                        .to_string();
-                                    if !name.is_empty() {
-                                        exports.push(ExportEntry {
-                                            name,
-                                            kind: ExportKind::Named,
-                                            line,
-                                        });
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    "lexical_declaration" | "variable_declaration" => {
-                        // `export const x = ...` or `export let x = ...`
-                        for j in 0..child.named_child_count() {
-                            if let Some(decl) = child.named_child(j) {
-                                if decl.kind() == "variable_declarator" {
-                                    if let Some(name_node) = decl.child_by_field_name("name") {
-                                        let name = name_node
-                                            .utf8_text(source.as_bytes())
-                                            .unwrap_or("")
-                                            .to_string();
-                                        if !name.is_empty() {
-                                            exports.push(ExportEntry {
-                                                name,
-                                                kind: ExportKind::Named,
-                                                line,
-                                            });
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    "function_declaration" | "class_declaration" | "abstract_class_declaration" => {
-                        let name = child
-                            .child_by_field_name("name")
-                            .and_then(|n| n.utf8_text(source.as_bytes()).ok())
-                            .unwrap_or("")
-                            .to_string();
-                        if !name.is_empty() {
-                            exports.push(ExportEntry {
-                                name,
-                                kind: ExportKind::Named,
-                                line,
-                            });
-                        }
-                    }
-                    "identifier" => {
-                        // `export default identifier`
-                        let name = child.utf8_text(source.as_bytes()).unwrap_or("").to_string();
-                        if !name.is_empty() {
-                            exports.push(ExportEntry {
-                                name,
-                                kind: ExportKind::Default,
-                                line,
-                            });
-                        }
-                    }
-                    _ => {}
+            let Some(child) = node.named_child(i) else {
+                continue;
+            };
+            match child.kind() {
+                "export_clause" => {
+                    Self::collect_export_clause(child, source, exports, line);
                 }
+                "lexical_declaration" | "variable_declaration" => {
+                    Self::collect_export_variable(child, source, exports, line);
+                }
+                "function_declaration" | "class_declaration" | "abstract_class_declaration" => {
+                    Self::collect_export_declaration(child, source, exports, line);
+                }
+                "identifier" => {
+                    Self::collect_export_identifier(child, source, exports, line);
+                }
+                _ => {}
             }
+        }
+    }
+
+    fn collect_export_clause(child: Node, source: &str, exports: &mut Vec<ExportEntry>, line: usize) {
+        for j in 0..child.named_child_count() {
+            let Some(spec) = child.named_child(j) else {
+                continue;
+            };
+            if spec.kind() != "export_specifier" {
+                continue;
+            }
+            let name = spec
+                .child_by_field_name("name")
+                .and_then(|n| n.utf8_text(source.as_bytes()).ok())
+                .unwrap_or("")
+                .to_string();
+            if !name.is_empty() {
+                exports.push(ExportEntry {
+                    name,
+                    kind: ExportKind::Named,
+                    line,
+                });
+            }
+        }
+    }
+
+    fn collect_export_variable(
+        child: Node,
+        source: &str,
+        exports: &mut Vec<ExportEntry>,
+        line: usize,
+    ) {
+        for j in 0..child.named_child_count() {
+            let Some(decl) = child.named_child(j) else {
+                continue;
+            };
+            if decl.kind() != "variable_declarator" {
+                continue;
+            }
+            let Some(name_node) = decl.child_by_field_name("name") else {
+                continue;
+            };
+            let name = name_node
+                .utf8_text(source.as_bytes())
+                .unwrap_or("")
+                .to_string();
+            if !name.is_empty() {
+                exports.push(ExportEntry {
+                    name,
+                    kind: ExportKind::Named,
+                    line,
+                });
+            }
+        }
+    }
+
+    fn collect_export_declaration(
+        child: Node,
+        source: &str,
+        exports: &mut Vec<ExportEntry>,
+        line: usize,
+    ) {
+        let name = child
+            .child_by_field_name("name")
+            .and_then(|n| n.utf8_text(source.as_bytes()).ok())
+            .unwrap_or("")
+            .to_string();
+        if !name.is_empty() {
+            exports.push(ExportEntry {
+                name,
+                kind: ExportKind::Named,
+                line,
+            });
+        }
+    }
+
+    fn collect_export_identifier(child: Node, source: &str, exports: &mut Vec<ExportEntry>, line: usize) {
+        let name = child.utf8_text(source.as_bytes()).unwrap_or("").to_string();
+        if !name.is_empty() {
+            exports.push(ExportEntry {
+                name,
+                kind: ExportKind::Default,
+                line,
+            });
         }
     }
 
@@ -463,6 +558,19 @@ impl TsParser {
 
         let line = node.start_position().row + 1;
 
+        Self::track_pw_tracked_calls(full_callee, node, source, line, pw_module);
+        Self::track_pw_evaluate(full_callee, node, source, line, pw_module);
+        Self::track_pw_axe(full_callee, pw_module);
+        Self::track_pw_locator_chains(full_callee, node, source, line, pw_module);
+    }
+
+    fn track_pw_tracked_calls(
+        full_callee: &str,
+        node: Node,
+        source: &str,
+        line: usize,
+        pw_module: &mut PlaywrightModule,
+    ) {
         let tracked_calls = [
             "waitForTimeout",
             "page.$",
@@ -487,24 +595,39 @@ impl TsParser {
                 break;
             }
         }
+    }
 
-        // Track evaluate innerText
+    fn track_pw_evaluate(
+        full_callee: &str,
+        node: Node,
+        source: &str,
+        line: usize,
+        pw_module: &mut PlaywrightModule,
+    ) {
         if full_callee.contains("evaluate") {
             let text = node.utf8_text(source.as_bytes()).unwrap_or("");
             if text.contains("innerText") {
                 pw_module.evaluate_inner_text.push(line);
             }
         }
+    }
 
-        // Track axe usage
+    fn track_pw_axe(full_callee: &str, pw_module: &mut PlaywrightModule) {
         if full_callee.contains("injectAxe")
             || full_callee.contains("checkA11y")
             || full_callee.contains("AxeBuilder")
         {
             pw_module.uses_axe = true;
         }
+    }
 
-        // Track locator chains
+    fn track_pw_locator_chains(
+        full_callee: &str,
+        node: Node,
+        source: &str,
+        line: usize,
+        pw_module: &mut PlaywrightModule,
+    ) {
         let locator_roots = [
             "getByRole",
             "getByText",
@@ -593,22 +716,7 @@ impl TsParser {
     fn collect_returned_keys(node: Node, source: &str, keys: &mut Vec<String>) {
         match node.kind() {
             "object" | "object_pattern" => {
-                // Collect keys from this object
-                for i in 0..node.named_child_count() {
-                    if let Some(child) = node.named_child(i) {
-                        if child.kind() == "pair" || child.kind() == "property" {
-                            if let Some(key) = child.child_by_field_name("key") {
-                                if let Ok(text) = key.utf8_text(source.as_bytes()) {
-                                    keys.push(text.to_string());
-                                }
-                            }
-                        } else if child.kind() == "shorthand_property_identifier" {
-                            if let Ok(text) = child.utf8_text(source.as_bytes()) {
-                                keys.push(text.to_string());
-                            }
-                        }
-                    }
-                }
+                Self::collect_object_keys(node, source, keys);
             }
             "statement_block" | "return_statement" | "parenthesized_expression" => {
                 for i in 0..node.named_child_count() {
@@ -618,6 +726,25 @@ impl TsParser {
                 }
             }
             _ => {}
+        }
+    }
+
+    fn collect_object_keys(node: Node, source: &str, keys: &mut Vec<String>) {
+        for i in 0..node.named_child_count() {
+            let Some(child) = node.named_child(i) else {
+                continue;
+            };
+            if child.kind() == "pair" || child.kind() == "property" {
+                if let Some(key) = child.child_by_field_name("key") {
+                    if let Ok(text) = key.utf8_text(source.as_bytes()) {
+                        keys.push(text.to_string());
+                    }
+                }
+            } else if child.kind() == "shorthand_property_identifier" {
+                if let Ok(text) = child.utf8_text(source.as_bytes()) {
+                    keys.push(text.to_string());
+                }
+            }
         }
     }
 
@@ -662,55 +789,68 @@ impl TsParser {
             };
             match child.kind() {
                 "identifier" => {
-                    let name = child.utf8_text(source.as_bytes()).unwrap_or("").to_string();
-                    if !name.is_empty() {
-                        entry.default = Some(name);
-                    }
+                    Self::walk_import_identifier(child, source, entry);
                 }
                 "namespace_import" => {
-                    for j in 0..child.named_child_count() {
-                        if let Some(inner) = child.named_child(j) {
-                            if inner.kind() == "identifier" {
-                                entry.namespace = Some(
-                                    inner.utf8_text(source.as_bytes()).unwrap_or("").to_string(),
-                                );
-                            }
-                        }
-                    }
+                    Self::walk_import_namespace(child, source, entry);
                 }
                 "named_imports" => {
-                    for j in 0..child.named_child_count() {
-                        if let Some(spec) = child.named_child(j) {
-                            if spec.kind() == "import_specifier" {
-                                // import_specifier has `name` and optional `alias`.
-                                let name = spec
-                                    .child_by_field_name("name")
-                                    .and_then(|n| n.utf8_text(source.as_bytes()).ok())
-                                    .unwrap_or("");
-                                if name.is_empty() {
-                                    // Fallback: first identifier child.
-                                    for k in 0..spec.named_child_count() {
-                                        if let Some(c) = spec.named_child(k) {
-                                            if c.kind() == "identifier" {
-                                                let n = c
-                                                    .utf8_text(source.as_bytes())
-                                                    .unwrap_or("")
-                                                    .to_string();
-                                                if !n.is_empty() {
-                                                    entry.named.push(n);
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                    }
-                                } else {
-                                    entry.named.push(name.to_string());
-                                }
-                            }
-                        }
-                    }
+                    Self::walk_import_named(child, source, entry);
                 }
                 _ => {}
+            }
+        }
+    }
+
+    fn walk_import_identifier(child: Node, source: &str, entry: &mut ImportEntry) {
+        let name = child.utf8_text(source.as_bytes()).unwrap_or("").to_string();
+        if !name.is_empty() {
+            entry.default = Some(name);
+        }
+    }
+
+    fn walk_import_namespace(child: Node, source: &str, entry: &mut ImportEntry) {
+        for j in 0..child.named_child_count() {
+            if let Some(inner) = child.named_child(j) {
+                if inner.kind() == "identifier" {
+                    entry.namespace = Some(
+                        inner.utf8_text(source.as_bytes()).unwrap_or("").to_string(),
+                    );
+                }
+            }
+        }
+    }
+
+    fn walk_import_named(child: Node, source: &str, entry: &mut ImportEntry) {
+        for j in 0..child.named_child_count() {
+            let Some(spec) = child.named_child(j) else {
+                continue;
+            };
+            if spec.kind() != "import_specifier" {
+                continue;
+            }
+            let name = spec
+                .child_by_field_name("name")
+                .and_then(|n| n.utf8_text(source.as_bytes()).ok())
+                .unwrap_or("");
+            if name.is_empty() {
+                Self::walk_import_named_fallback(spec, source, entry);
+            } else {
+                entry.named.push(name.to_string());
+            }
+        }
+    }
+
+    fn walk_import_named_fallback(spec: Node, source: &str, entry: &mut ImportEntry) {
+        for k in 0..spec.named_child_count() {
+            if let Some(c) = spec.named_child(k) {
+                if c.kind() == "identifier" {
+                    let n = c.utf8_text(source.as_bytes()).unwrap_or("").to_string();
+                    if !n.is_empty() {
+                        entry.named.push(n);
+                        break;
+                    }
+                }
             }
         }
     }
@@ -877,7 +1017,14 @@ impl TsParser {
         if cb.kind() != "arrow_function" && cb.kind() != "function_expression" {
             return false;
         }
-        let params = cb.child_by_field_name("parameters").or_else(|| {
+        let Some(params) = Self::find_params_node(cb) else {
+            return false;
+        };
+        Self::check_done_in_params(params, source)
+    }
+
+    fn find_params_node(cb: Node) -> Option<Node> {
+        cb.child_by_field_name("parameters").or_else(|| {
             for i in 0..cb.named_child_count() {
                 let child = cb.named_child(i)?;
                 if child.kind() == "formal_parameters" {
@@ -885,35 +1032,38 @@ impl TsParser {
                 }
             }
             None
-        });
-        if let Some(params) = params {
-            for i in 0..params.named_child_count() {
-                if let Some(param) = params.named_child(i) {
-                    match param.kind() {
-                        "identifier"
-                            if param.utf8_text(source.as_bytes()).unwrap_or("") == "done" =>
-                        {
-                            return true;
-                        }
-                        "required_parameter" => {
-                            // required_parameter wraps an identifier or pattern
-                            for j in 0..param.named_child_count() {
-                                if let Some(inner) = param.named_child(j) {
-                                    if inner.kind() == "identifier"
-                                        && inner.utf8_text(source.as_bytes()).unwrap_or("")
-                                            == "done"
-                                    {
-                                        return true;
-                                    }
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                }
+        })
+    }
+
+    fn check_done_in_params(params: Node, source: &str) -> bool {
+        for i in 0..params.named_child_count() {
+            let Some(param) = params.named_child(i) else {
+                continue;
+            };
+            if Self::is_done_identifier(param, source) {
+                return true;
             }
         }
         false
+    }
+
+    fn is_done_identifier(param: Node, source: &str) -> bool {
+        match param.kind() {
+            "identifier" => param.utf8_text(source.as_bytes()).unwrap_or("") == "done",
+            "required_parameter" => {
+                for j in 0..param.named_child_count() {
+                    if let Some(inner) = param.named_child(j) {
+                        if inner.kind() == "identifier"
+                            && inner.utf8_text(source.as_bytes()).unwrap_or("") == "done"
+                        {
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
+            _ => false,
+        }
     }
 
     fn string_value(node: Node, source: &str) -> Option<String> {
@@ -968,130 +1118,148 @@ impl TsParser {
     fn walk_body(node: Node, source: &str, st: &mut Analysis) {
         match node.kind() {
             "call_expression" => {
-                let func = node.child_by_field_name("function").unwrap();
-                let text = func.utf8_text(source.as_bytes()).unwrap_or("");
-                // Only count expect() calls where the function is a simple identifier
-                // (not a chained member expression like expect(x).toBe).
-                let is_expect_call = func.kind() == "identifier" && text == "expect";
-                if is_expect_call {
-                    st.assertion_count += 1;
-                    // Mark expect inside conditional
-                    if st.in_conditional {
-                        st.has_conditional_expect = true;
-                    }
-                    // Check if expect() is called without a chained assertion method.
-                    // If the expect call is inside a member_expression that is itself
-                    // inside a call_expression, it has a chained assertion (e.g. expect(x).toBe(y)).
-                    let has_chained_assertion = Self::has_parent_member_call(node);
-                    if !has_chained_assertion {
-                        st.has_expect_call_without_assertion = true;
-                    }
-                    // Check if this is a weak assertion (e.g. toBeDefined, toBeTruthy).
-                    if let Some((matcher, negated)) = Self::expect_matcher_info(node, source) {
-                        let is_weak_matcher = Self::WEAK_MATCHERS.contains(&matcher);
-                        let is_negated_throw = negated && matcher == "toThrow";
-                        if is_weak_matcher || is_negated_throw {
-                            st.weak_assertion_count += 1;
-                        }
-                    }
-                    // Check if expect() wraps an async function.
-                    if let Some(args) = node.child_by_field_name("arguments") {
-                        if let Some(first_arg) = args.named_child(0) {
-                            if first_arg.kind() == "arrow_function"
-                                || first_arg.kind() == "function_expression"
-                            {
-                                let func_text =
-                                    first_arg.utf8_text(source.as_bytes()).unwrap_or("");
-                                if func_text.trim_start().starts_with("async") {
-                                    st.has_async_expect_wrapper = true;
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    // For non-expect calls, walk the function field to find nested expect calls
-                    // (e.g., expect(x).toBe(y) or expect(async () => ...).not.toThrow()).
-                    Self::walk_body(func, source, st);
-                }
-                // Check for unawaited async assertions (.resolves/.rejects).
-                // This applies to any call that contains these in its text.
-                if (text.contains(".resolves") || text.contains(".rejects"))
-                    && !Self::is_awaited(node)
-                {
-                    st.unawaited_async_assertions += 1;
-                }
-                if text == "setTimeout" {
-                    st.uses_settimeout = true;
-                    if st.in_promise_constructor {
-                        st.uses_promise_settimeout = true;
-                    }
-                }
-                if text.starts_with("Date.") {
-                    st.uses_datemock = true;
-                }
-                if text == "vi.useFakeTimers" {
-                    st.uses_fake_timers = true;
-                }
-                if text == "vi.useRealTimers" {
-                    st.has_real_timers_call = true;
-                }
-                if text == "Math.random" || text == "crypto.randomUUID" {
-                    st.uses_random = true;
-                }
-                let args = node.child_by_field_name("arguments").unwrap();
-                for i in 0..args.named_child_count() {
-                    let child = args.named_child(i).unwrap();
-                    Self::walk_body(child, source, st);
-                }
+                Self::walk_call_expression(node, source, st);
                 return;
             }
             "new_expression" => {
-                let ctor = node.child_by_field_name("constructor").unwrap();
-                let ctor_text = ctor.utf8_text(source.as_bytes()).unwrap_or("");
-                if ctor_text == "Date" {
-                    st.uses_datemock = true;
-                }
-                let is_promise = ctor_text == "Promise";
-                let prev_in_promise_constructor = st.in_promise_constructor;
-                if is_promise {
-                    st.in_promise_constructor = true;
-                }
-                if let Some(args) = node.child_by_field_name("arguments") {
-                    for i in 0..args.named_child_count() {
-                        let child = args.named_child(i).unwrap();
-                        Self::walk_body(child, source, st);
-                    }
-                }
-                st.in_promise_constructor = prev_in_promise_constructor;
+                Self::walk_new_expression(node, source, st);
             }
             "if_statement" | "switch_statement" => {
-                st.has_conditional = true;
-                let prev = st.in_conditional;
-                st.in_conditional = true;
-                for i in 0..node.named_child_count() {
-                    let child = node.named_child(i).unwrap();
-                    Self::walk_body(child, source, st);
-                }
-                st.in_conditional = prev;
+                Self::walk_conditional(node, source, st);
                 return;
             }
             "try_statement" => {
                 st.has_try_catch = true;
             }
             "return_statement" => {
-                st.has_return = true;
-                // Check if return contains an expect call.
-                for i in 0..node.named_child_count() {
-                    let child = node.named_child(i).unwrap();
-                    if Self::contains_expect_call(child, source) {
-                        st.has_return_of_expect = true;
-                        break;
-                    }
-                }
+                Self::walk_return_statement(node, source, st);
             }
             _ => {}
         }
 
+        Self::walk_body_children(node, source, st);
+    }
+
+    fn walk_call_expression(node: Node, source: &str, st: &mut Analysis) {
+        let func = node.child_by_field_name("function").unwrap();
+        let text = func.utf8_text(source.as_bytes()).unwrap_or("");
+        let is_expect_call = func.kind() == "identifier" && text == "expect";
+
+        if is_expect_call {
+            Self::handle_expect_call(node, source, st);
+        } else {
+            Self::walk_body(func, source, st);
+        }
+
+        Self::walk_call_flags(node, text, st);
+
+        let args = node.child_by_field_name("arguments").unwrap();
+        for i in 0..args.named_child_count() {
+            let child = args.named_child(i).unwrap();
+            Self::walk_body(child, source, st);
+        }
+    }
+
+    fn handle_expect_call(node: Node, source: &str, st: &mut Analysis) {
+        st.assertion_count += 1;
+        if st.in_conditional {
+            st.has_conditional_expect = true;
+        }
+        let has_chained_assertion = Self::has_parent_member_call(node);
+        if !has_chained_assertion {
+            st.has_expect_call_without_assertion = true;
+        }
+        if let Some((matcher, negated)) = Self::expect_matcher_info(node, source) {
+            let is_weak_matcher = Self::WEAK_MATCHERS.contains(&matcher);
+            let is_negated_throw = negated && matcher == "toThrow";
+            if is_weak_matcher || is_negated_throw {
+                st.weak_assertion_count += 1;
+            }
+        }
+        Self::check_async_expect_wrapper(node, source, st);
+    }
+
+    fn check_async_expect_wrapper(node: Node, source: &str, st: &mut Analysis) {
+        let Some(args) = node.child_by_field_name("arguments") else {
+            return;
+        };
+        let Some(first_arg) = args.named_child(0) else {
+            return;
+        };
+        if first_arg.kind() == "arrow_function" || first_arg.kind() == "function_expression" {
+            let func_text = first_arg.utf8_text(source.as_bytes()).unwrap_or("");
+            if func_text.trim_start().starts_with("async") {
+                st.has_async_expect_wrapper = true;
+            }
+        }
+    }
+
+    fn walk_call_flags(node: Node, text: &str, st: &mut Analysis) {
+        if (text.contains(".resolves") || text.contains(".rejects")) && !Self::is_awaited(node) {
+            st.unawaited_async_assertions += 1;
+        }
+        if text == "setTimeout" {
+            st.uses_settimeout = true;
+            if st.in_promise_constructor {
+                st.uses_promise_settimeout = true;
+            }
+        }
+        if text.starts_with("Date.") {
+            st.uses_datemock = true;
+        }
+        if text == "vi.useFakeTimers" {
+            st.uses_fake_timers = true;
+        }
+        if text == "vi.useRealTimers" {
+            st.has_real_timers_call = true;
+        }
+        if text == "Math.random" || text == "crypto.randomUUID" {
+            st.uses_random = true;
+        }
+    }
+
+    fn walk_new_expression(node: Node, source: &str, st: &mut Analysis) {
+        let ctor = node.child_by_field_name("constructor").unwrap();
+        let ctor_text = ctor.utf8_text(source.as_bytes()).unwrap_or("");
+        if ctor_text == "Date" {
+            st.uses_datemock = true;
+        }
+        let prev_in_promise_constructor = st.in_promise_constructor;
+        if ctor_text == "Promise" {
+            st.in_promise_constructor = true;
+        }
+        if let Some(args) = node.child_by_field_name("arguments") {
+            for i in 0..args.named_child_count() {
+                let child = args.named_child(i).unwrap();
+                Self::walk_body(child, source, st);
+            }
+        }
+        st.in_promise_constructor = prev_in_promise_constructor;
+    }
+
+    fn walk_conditional(node: Node, source: &str, st: &mut Analysis) {
+        st.has_conditional = true;
+        let prev = st.in_conditional;
+        st.in_conditional = true;
+        for i in 0..node.named_child_count() {
+            let child = node.named_child(i).unwrap();
+            Self::walk_body(child, source, st);
+        }
+        st.in_conditional = prev;
+    }
+
+    fn walk_return_statement(node: Node, source: &str, st: &mut Analysis) {
+        st.has_return = true;
+        for i in 0..node.named_child_count() {
+            let child = node.named_child(i).unwrap();
+            if Self::contains_expect_call(child, source) {
+                st.has_return_of_expect = true;
+                break;
+            }
+        }
+    }
+
+    fn walk_body_children(node: Node, source: &str, st: &mut Analysis) {
         for i in 0..node.named_child_count() {
             let child = node.named_child(i).unwrap();
             Self::walk_body(child, source, st);
@@ -1123,17 +1291,20 @@ impl TsParser {
     /// For `expect(x).not.toBe(2)`, returns `("toBe", true)`.
     /// For `expect(() => fn()).not.toThrow()`, returns `("toThrow", true)`.
     fn expect_matcher_info<'a>(expect_node: Node, source: &'a str) -> Option<(&'a str, bool)> {
-        // Walk up from expect to find the outermost call_expression in the chain.
-        // Handles patterns like: expect(x).toBe(y), expect(x).not.toThrow(), etc.
-        let mut curr = expect_node;
+        let (curr, has_not) = Self::walk_up_chain(expect_node, source)?;
+        Self::extract_matcher_from_call(curr, source, has_not)
+    }
+
+    /// Walk up from `expect_node` to find the outermost call_expression in the chain.
+    /// Handles patterns like: expect(x).toBe(y), expect(x).not.toThrow(), etc.
+    fn walk_up_chain<'a>(node: Node<'a>, source: &'a str) -> Option<(Node<'a>, bool)> {
+        let mut curr = node;
         let mut has_not = false;
         loop {
             let parent = curr.parent()?;
             if parent.kind() == "member_expression" {
-                if let Some(prop) = parent.child_by_field_name("property") {
-                    if prop.utf8_text(source.as_bytes()).unwrap_or("") == "not" {
-                        has_not = true;
-                    }
+                if Self::is_not_property(parent, source) {
+                    has_not = true;
                 }
                 let grandparent = parent.parent()?;
                 if grandparent.kind() == "call_expression"
@@ -1143,7 +1314,6 @@ impl TsParser {
                     continue;
                 }
             } else if parent.kind() == "call_expression" {
-                // e.g. curr = member_expression (.toThrow), parent = call_expression (toThrow())
                 let grandparent = parent.parent()?;
                 if grandparent.kind() == "member_expression" {
                     curr = grandparent;
@@ -1153,6 +1323,19 @@ impl TsParser {
             }
             break;
         }
+        Some((curr, has_not))
+    }
+
+    fn is_not_property(node: Node, source: &str) -> bool {
+        node.child_by_field_name("property")
+            .is_some_and(|prop| prop.utf8_text(source.as_bytes()).unwrap_or("") == "not")
+    }
+
+    fn extract_matcher_from_call<'a>(
+        curr: Node,
+        source: &'a str,
+        has_not: bool,
+    ) -> Option<(&'a str, bool)> {
         if curr.kind() == "call_expression" {
             if let Some(func) = curr.child_by_field_name("function") {
                 if func.kind() == "member_expression" {

--- a/src/rules/dependencies.rs
+++ b/src/rules/dependencies.rs
@@ -1,5 +1,6 @@
 use crate::config::matches_path;
-use crate::models::{Category, ModuleGraph, ParsedModule, Severity, Violation};
+use crate::config::BannedSingleton;
+use crate::models::{Category, ImportEntry, ModuleGraph, ParsedModule, Severity, ViMockCall, Violation};
 use crate::rules::{LintContext, Rule};
 
 const STABLE_DEP_SUFFIXES: &[&str] = &[
@@ -150,60 +151,14 @@ impl Rule for ProductionSingletonImportRule {
             }
         }
 
+        let rid = self.id();
+        let rname = self.name();
+        let sev = self.severity();
+        let cat = self.category();
         let mut out = Vec::new();
         for imp in &module.imports_parsed {
             for ban in banned {
-                if !ban.from.is_match(imp.source.as_str())
-                    && !ban.from.is_match(strip_relative(imp.source.as_str()))
-                {
-                    continue;
-                }
-                // Check named imports.
-                for name in &imp.named {
-                    if ban.names.iter().any(|n| n == name) {
-                        out.push(Violation {
-                            rule_id: self.id().to_string(),
-                            rule_name: self.name().to_string(),
-                            severity: self.severity(),
-                            category: self.category(),
-                            message: format!(
-                                "Importing production singleton `{}` from `{}` triggers its constructor side effects in unit tests",
-                                name, imp.source
-                            ),
-                            file_path: module.file_path.clone(),
-                            line: imp.line,
-                            col: None,
-                            suggestion: Some(
-                                "Construct a fresh instance with fakes (DI). Singletons belong in *.integration.test.ts only."
-                                    .to_string(),
-                            ),
-                            test_name: None,
-                        });
-                    }
-                }
-                // Check default import.
-                if let Some(default_name) = &imp.default {
-                    if ban.names.iter().any(|n| n == default_name) {
-                        out.push(Violation {
-                            rule_id: self.id().to_string(),
-                            rule_name: self.name().to_string(),
-                            severity: self.severity(),
-                            category: self.category(),
-                            message: format!(
-                                "Importing production singleton `{}` from `{}` triggers its constructor side effects in unit tests",
-                                default_name, imp.source
-                            ),
-                            file_path: module.file_path.clone(),
-                            line: imp.line,
-                            col: None,
-                            suggestion: Some(
-                                "Construct a fresh instance with fakes (DI). Singletons belong in *.integration.test.ts only."
-                                    .to_string(),
-                            ),
-                            test_name: None,
-                        });
-                    }
-                }
+                out.extend(check_singleton_import(imp, ban, module, rid, rname, sev, cat));
             }
         }
         out
@@ -288,70 +243,90 @@ impl Rule for MockExportValidationRule {
         ctx: &LintContext<'_>,
         graph: &ModuleGraph,
     ) -> Vec<Violation> {
+        let rid = self.id();
+        let rname = self.name();
+        let sev = self.severity();
+        let cat = self.category();
         let mut violations = Vec::new();
 
         for mock in &module.vi_mocks {
-            // Skip if no factory function
             if mock.factory_keys.is_empty() {
                 continue;
             }
 
-            // Try to resolve the mock source to a source module in the graph
-            let resolved = ctx.config.resolve_module_path(&mock.source);
-            let source_module = graph
-                .get_module(std::path::Path::new(&resolved))
-                .or_else(|| {
-                    // Try resolving relative imports by checking extensions
-                    if resolved.starts_with('.') {
-                        if let Some(parent) = module.file_path.parent() {
-                            let base = parent.join(&resolved);
-                            let exts = ["ts", "tsx", "js", "jsx"];
-                            for ext in &exts {
-                                let candidate = base.with_extension(ext);
-                                if let Some(m) = graph.get_module(&candidate) {
-                                    return Some(m);
-                                }
-                            }
-                        }
-                    }
-                    None
-                });
-
-            if let Some(source_module) = source_module {
-                let export_names: Vec<String> = source_module
-                    .exports
-                    .iter()
-                    .map(|e| e.name.clone())
-                    .collect();
-
-                // Check if factory keys match exports
-                for key in &mock.factory_keys {
-                    if !export_names.contains(key) && key != "__esModule" {
-                        violations.push(Violation {
-                            rule_id: self.id().to_string(),
-                            rule_name: self.name().to_string(),
-                            severity: self.severity(),
-                            category: self.category(),
-                            message: format!(
-                                "vi.mock('{}') factory returns '{}' which is not exported by the source module",
-                                mock.source, key
-                            ),
-                            file_path: module.file_path.clone(),
-                            line: mock.line,
-                            col: None,
-                            suggestion: Some(
-                                "Remove the non-existent export from the mock factory or add it to the source module"
-                                    .to_string(),
-                            ),
-                            test_name: None,
-                        });
-                    }
-                }
+            let source_module = resolve_mock_source_module(mock, module, ctx, graph);
+            if let Some(sm) = source_module {
+                violations.extend(validate_factory_keys(mock, sm, module, rid, rname, sev, cat));
             }
         }
 
         violations
     }
+}
+
+fn resolve_mock_source_module<'a>(
+    mock: &ViMockCall,
+    module: &ParsedModule,
+    ctx: &LintContext<'_>,
+    graph: &'a ModuleGraph,
+) -> Option<&'a ParsedModule> {
+    let resolved = ctx.config.resolve_module_path(&mock.source);
+    graph
+        .get_module(std::path::Path::new(&resolved))
+        .or_else(|| {
+            if resolved.starts_with('.') {
+                if let Some(parent) = module.file_path.parent() {
+                    let base = parent.join(&resolved);
+                    for ext in ["ts", "tsx", "js", "jsx"] {
+                        if let Some(m) = graph.get_module(&base.with_extension(ext)) {
+                            return Some(m);
+                        }
+                    }
+                }
+            }
+            None
+        })
+}
+
+fn validate_factory_keys(
+    mock: &ViMockCall,
+    source_module: &ParsedModule,
+    module: &ParsedModule,
+    rule_id: &str,
+    rule_name: &str,
+    severity: Severity,
+    category: Category,
+) -> Vec<Violation> {
+    let export_names: Vec<String> = source_module
+        .exports
+        .iter()
+        .map(|e| e.name.clone())
+        .collect();
+
+    let mut violations = Vec::new();
+    for key in &mock.factory_keys {
+        if !export_names.contains(key) && key != "__esModule" {
+            violations.push(Violation {
+                rule_id: rule_id.to_string(),
+                rule_name: rule_name.to_string(),
+                severity,
+                category,
+                message: format!(
+                    "vi.mock('{}') factory returns '{}' which is not exported by the source module",
+                    mock.source, key
+                ),
+                file_path: module.file_path.clone(),
+                line: mock.line,
+                col: None,
+                suggestion: Some(
+                    "Remove the non-existent export from the mock factory or add it to the source module"
+                        .to_string(),
+                ),
+                test_name: None,
+            });
+        }
+    }
+    violations
 }
 
 fn strip_relative(s: &str) -> &str {
@@ -360,6 +335,64 @@ fn strip_relative(s: &str) -> &str {
         s = rest;
     }
     s
+}
+
+fn make_singleton_violation(
+    name: &str,
+    imp: &ImportEntry,
+    module: &ParsedModule,
+    rule_id: &str,
+    rule_name: &str,
+    severity: Severity,
+    category: Category,
+) -> Violation {
+    Violation {
+        rule_id: rule_id.to_string(),
+        rule_name: rule_name.to_string(),
+        severity,
+        category,
+        message: format!(
+            "Importing production singleton `{}` from `{}` triggers its constructor side effects in unit tests",
+            name, imp.source
+        ),
+        file_path: module.file_path.clone(),
+        line: imp.line,
+        col: None,
+        suggestion: Some(
+            "Construct a fresh instance with fakes (DI). Singletons belong in *.integration.test.ts only."
+                .to_string(),
+        ),
+        test_name: None,
+    }
+}
+
+fn check_singleton_import(
+    imp: &ImportEntry,
+    ban: &BannedSingleton,
+    module: &ParsedModule,
+    rule_id: &str,
+    rule_name: &str,
+    severity: Severity,
+    category: Category,
+) -> Vec<Violation> {
+    if !ban.from.is_match(imp.source.as_str())
+        && !ban.from.is_match(strip_relative(imp.source.as_str()))
+    {
+        return vec![];
+    }
+
+    let mut out = Vec::new();
+    for name in &imp.named {
+        if ban.names.iter().any(|n| n == name) {
+            out.push(make_singleton_violation(name, imp, module, rule_id, rule_name, severity, category));
+        }
+    }
+    if let Some(default_name) = &imp.default {
+        if ban.names.iter().any(|n| n == default_name) {
+            out.push(make_singleton_violation(default_name, imp, module, rule_id, rule_name, severity, category));
+        }
+    }
+    out
 }
 
 #[cfg(test)]

--- a/src/rules/maintenance.rs
+++ b/src/rules/maintenance.rs
@@ -1,5 +1,5 @@
 use crate::models::{
-    Category, HookKind, ModuleGraph, ParsedModule, Severity, TestRuntime, Violation,
+    Category, HookKind, ModuleGraph, ParsedModule, Severity, TestBlock, TestRuntime, Violation,
 };
 use crate::rules::Rule;
 
@@ -650,52 +650,14 @@ impl ImplementationCoupledRule {
         _ctx: &crate::rules::LintContext<'_>,
         graph: &ModuleGraph,
     ) -> Option<Violation> {
-        let prod_imports: Vec<&str> = module
-            .imports_parsed
-            .iter()
-            .filter(|imp| {
-                !imp.source.starts_with("vitest")
-                    && !imp.source.starts_with("@testing-library")
-                    && !imp.source.starts_with("jest")
-                    && !imp.source.starts_with("@jest")
-                    && !imp.source.contains("node_modules")
-            })
-            .map(|imp| imp.source.as_str())
-            .collect();
+        let prod_imports = Self::filter_prod_imports(module);
 
         if prod_imports.len() != 1 {
             return None;
         }
 
-        // Resolve the source module from the graph and get its exports.
         let source_module_path = prod_imports[0];
-        let resolved = _ctx.config.resolve_module_path(source_module_path);
-        let source_module = graph
-            .get_module(std::path::Path::new(&resolved))
-            .or_else(|| {
-                // Try resolving relative imports by checking extensions and index files
-                if resolved.starts_with('.') || resolved.starts_with('/') {
-                    if let Some(parent) = module.file_path.parent() {
-                        let base = parent.join(&resolved);
-                        let exts = ["ts", "tsx", "js", "jsx"];
-                        for ext in &exts {
-                            let candidate = base.with_extension(ext);
-                            if let Some(m) = graph.get_module(&candidate) {
-                                return Some(m);
-                            }
-                        }
-                        for ext in &exts {
-                            let candidate = base.join(format!("index.{}", ext));
-                            if let Some(m) = graph.get_module(&candidate) {
-                                return Some(m);
-                            }
-                        }
-                    }
-                }
-                None
-            });
-
-        let source_module = source_module?;
+        let source_module = Self::resolve_source_module(module, source_module_path, _ctx, graph)?;
 
         let export_count = source_module.exports.len();
         let test_count = module.test_blocks.len();
@@ -715,18 +677,7 @@ impl ImplementationCoupledRule {
             .map(|e| e.name.to_lowercase())
             .collect();
 
-        let matching = module
-            .test_blocks
-            .iter()
-            .filter(|tb| {
-                let test_name_lower = tb.name.to_lowercase();
-                export_names
-                    .iter()
-                    .any(|en| contains_word(&test_name_lower, en))
-            })
-            .count();
-
-        let match_ratio = matching as f64 / test_count as f64;
+        let match_ratio = Self::compute_name_match_ratio(&module.test_blocks, &export_names);
         if match_ratio < 0.8 {
             return None;
         }
@@ -752,6 +703,68 @@ impl ImplementationCoupledRule {
             ),
             test_name: None,
         })
+    }
+
+    /// Filters out test-framework / node_modules imports, keeping only production imports.
+    fn filter_prod_imports(module: &ParsedModule) -> Vec<&str> {
+        module
+            .imports_parsed
+            .iter()
+            .filter(|imp| {
+                !imp.source.starts_with("vitest")
+                    && !imp.source.starts_with("@testing-library")
+                    && !imp.source.starts_with("jest")
+                    && !imp.source.starts_with("@jest")
+                    && !imp.source.contains("node_modules")
+            })
+            .map(|imp| imp.source.as_str())
+            .collect()
+    }
+
+    /// Resolves an import path to a parsed module, trying relative paths with extensions
+    /// and index files when the direct path doesn't match.
+    fn resolve_source_module<'a>(
+        module: &ParsedModule,
+        source_path: &str,
+        ctx: &crate::rules::LintContext<'_>,
+        graph: &'a ModuleGraph,
+    ) -> Option<&'a ParsedModule> {
+        let resolved = ctx.config.resolve_module_path(source_path);
+        graph.get_module(std::path::Path::new(&resolved)).or_else(|| {
+            if resolved.starts_with('.') || resolved.starts_with('/') {
+                if let Some(parent) = module.file_path.parent() {
+                    let base = parent.join(&resolved);
+                    let exts = ["ts", "tsx", "js", "jsx"];
+                    for ext in &exts {
+                        let candidate = base.with_extension(ext);
+                        if let Some(m) = graph.get_module(&candidate) {
+                            return Some(m);
+                        }
+                    }
+                    for ext in &exts {
+                        let candidate = base.join(format!("index.{}", ext));
+                        if let Some(m) = graph.get_module(&candidate) {
+                            return Some(m);
+                        }
+                    }
+                }
+            }
+            None
+        })
+    }
+
+    /// Computes the fraction of test blocks whose names contain at least one export name.
+    fn compute_name_match_ratio(test_blocks: &[TestBlock], export_names: &[String]) -> f64 {
+        let matching = test_blocks
+            .iter()
+            .filter(|tb| {
+                let test_name_lower = tb.name.to_lowercase();
+                export_names
+                    .iter()
+                    .any(|en| contains_word(&test_name_lower, en))
+            })
+            .count();
+        matching as f64 / test_blocks.len() as f64
     }
 }
 

--- a/src/rules/require.rs
+++ b/src/rules/require.rs
@@ -159,47 +159,52 @@ impl Rule for RequireToThrowMessageRule {
     }
 }
 
+fn has_empty_throw_args(after: &str) -> bool {
+    // after is the text following "toThrow", starting with '('
+    let rest = after.strip_prefix('(').expect("must start with '('");
+    let mut depth = 1_u32;
+    let mut has_content = false;
+
+    for ch in rest.chars() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            _ => {
+                if depth == 1 && !ch.is_whitespace() && ch != ',' {
+                    has_content = true;
+                }
+            }
+        }
+    }
+
+    !has_content
+}
+
+fn has_empty_to_throw_no_parens(after: &str) -> bool {
+    let trimmed = after.trim_start();
+    trimmed.is_empty()
+        || trimmed.starts_with('.')
+        || trimmed.starts_with(';')
+        || trimmed.starts_with(')')
+}
+
 fn has_empty_to_throw(line: &str) -> bool {
     let mut search_from = 0;
     while let Some(pos) = line[search_from..].find("toThrow") {
         let abs_pos = search_from + pos;
         let after = &line[abs_pos + "toThrow".len()..];
 
-        if let Some(rest) = after.strip_prefix('(') {
-            let depth = 1;
-            let char_iter = rest.char_indices();
-            let mut d = depth;
-            let mut has_content = false;
-
-            for (_, ch) in char_iter {
-                match ch {
-                    '(' => d += 1,
-                    ')' => {
-                        d -= 1;
-                        if d == 0 {
-                            break;
-                        }
-                    }
-                    _ => {
-                        if d == 1 && !ch.is_whitespace() && ch != ',' {
-                            has_content = true;
-                        }
-                    }
-                }
-            }
-
-            if !has_content {
+        if after.starts_with('(') {
+            if has_empty_throw_args(after) {
                 return true;
             }
-        } else {
-            let trimmed_after = after.trim_start();
-            if trimmed_after.is_empty()
-                || trimmed_after.starts_with('.')
-                || trimmed_after.starts_with(';')
-                || trimmed_after.starts_with(')')
-            {
-                return true;
-            }
+        } else if has_empty_to_throw_no_parens(after) {
+            return true;
         }
 
         search_from = abs_pos + 1;

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -36,96 +36,136 @@ impl SuppressionMap {
 
         for (idx, line) in lines.iter().enumerate() {
             let line_num = idx + 1;
-            let trimmed = line.trim();
-
-            // Only process single-line comments
-            let comment_text = if let Some(text) = trimmed.strip_prefix("//") {
-                text.trim()
-            } else {
-                // Not a comment - propagate range suppressions
-                Self::propagate_range(
-                    line_num,
-                    &active_ranges,
-                    active_all_range,
-                    &enable_exceptions,
-                    &mut map,
-                );
-                continue;
-            };
-
-            if let Some(rest) = comment_text.strip_prefix(DISABLE_NEXT_LINE) {
-                let rules = parse_rule_ids(rest.trim());
-                let target_line = line_num + 1;
-                // Merge with any existing rules for the same target line
-                let entry = map
-                    .next_line
-                    .entry(target_line)
-                    .or_insert_with(HashSet::new);
-                if rules.is_empty() {
-                    // No specific rules = suppress all
-                    entry.insert(ALL_RULES.to_string());
-                } else {
-                    entry.extend(rules);
-                }
-                Self::propagate_range(
-                    line_num,
-                    &active_ranges,
-                    active_all_range,
-                    &enable_exceptions,
-                    &mut map,
-                );
-            } else if let Some(rest) = comment_text.strip_prefix(ENABLE) {
-                let rules = parse_rule_ids(rest.trim());
-                if rules.is_empty() {
-                    active_all_range = None;
-                    active_ranges.clear();
-                    enable_exceptions.clear();
-                } else if active_all_range.is_some() {
-                    // Record as exceptions to the active all-range
-                    for rule_id in &rules {
-                        enable_exceptions.insert(rule_id.clone());
-                    }
-                } else {
-                    for rule_id in &rules {
-                        active_ranges.remove(rule_id);
-                    }
-                }
-                Self::propagate_range(
-                    line_num,
-                    &active_ranges,
-                    active_all_range,
-                    &enable_exceptions,
-                    &mut map,
-                );
-            } else if let Some(rest) = comment_text.strip_prefix(DISABLE) {
-                let rules = parse_rule_ids(rest.trim());
-                if rules.is_empty() {
-                    active_all_range = Some(line_num);
-                    enable_exceptions.clear();
-                } else {
-                    for rule_id in rules {
-                        active_ranges.entry(rule_id).or_insert(line_num);
-                    }
-                }
-                Self::propagate_range(
-                    line_num,
-                    &active_ranges,
-                    active_all_range,
-                    &enable_exceptions,
-                    &mut map,
-                );
-            } else {
-                Self::propagate_range(
-                    line_num,
-                    &active_ranges,
-                    active_all_range,
-                    &enable_exceptions,
-                    &mut map,
-                );
-            }
+            Self::handle_line(
+                line,
+                line_num,
+                &mut active_ranges,
+                &mut active_all_range,
+                &mut enable_exceptions,
+                &mut map,
+            );
         }
 
         map
+    }
+
+    fn handle_line(
+        line: &str,
+        line_num: usize,
+        active_ranges: &mut HashMap<String, usize>,
+        active_all_range: &mut Option<usize>,
+        enable_exceptions: &mut HashSet<String>,
+        map: &mut SuppressionMap,
+    ) {
+        let trimmed = line.trim();
+
+        let comment_text = if let Some(text) = trimmed.strip_prefix("//") {
+            text.trim()
+        } else {
+            Self::propagate_range(line_num, active_ranges, *active_all_range, enable_exceptions, map);
+            return;
+        };
+
+        if let Some(rest) = comment_text.strip_prefix(DISABLE_NEXT_LINE) {
+            Self::handle_disable_next_line(
+                rest.trim(),
+                line_num,
+                map,
+                active_ranges,
+                *active_all_range,
+                enable_exceptions,
+            );
+        } else if let Some(rest) = comment_text.strip_prefix(ENABLE) {
+            Self::handle_enable(
+                rest.trim(),
+                line_num,
+                active_ranges,
+                active_all_range,
+                enable_exceptions,
+                map,
+            );
+        } else if let Some(rest) = comment_text.strip_prefix(DISABLE) {
+            Self::handle_disable(
+                rest.trim(),
+                line_num,
+                active_ranges,
+                active_all_range,
+                enable_exceptions,
+                map,
+            );
+        } else {
+            Self::propagate_range(line_num, active_ranges, *active_all_range, enable_exceptions, map);
+        }
+    }
+
+    fn handle_disable_next_line(
+        rest: &str,
+        line_num: usize,
+        map: &mut SuppressionMap,
+        active_ranges: &HashMap<String, usize>,
+        active_all_range: Option<usize>,
+        enable_exceptions: &HashSet<String>,
+    ) {
+        let rules = parse_rule_ids(rest);
+        let target_line = line_num + 1;
+        // Merge with any existing rules for the same target line
+        let entry = map
+            .next_line
+            .entry(target_line)
+            .or_default();
+        if rules.is_empty() {
+            // No specific rules = suppress all
+            entry.insert(ALL_RULES.to_string());
+        } else {
+            entry.extend(rules);
+        }
+        Self::propagate_range(line_num, active_ranges, active_all_range, enable_exceptions, map);
+    }
+
+    fn handle_enable(
+        rest: &str,
+        line_num: usize,
+        active_ranges: &mut HashMap<String, usize>,
+        active_all_range: &mut Option<usize>,
+        enable_exceptions: &mut HashSet<String>,
+        map: &mut SuppressionMap,
+    ) {
+        let rules = parse_rule_ids(rest);
+        if rules.is_empty() {
+            *active_all_range = None;
+            active_ranges.clear();
+            enable_exceptions.clear();
+        } else if active_all_range.is_some() {
+            // Record as exceptions to the active all-range
+            for rule_id in &rules {
+                enable_exceptions.insert(rule_id.clone());
+            }
+        } else {
+            for rule_id in &rules {
+                active_ranges.remove(rule_id);
+            }
+        }
+        Self::propagate_range(line_num, active_ranges, *active_all_range, enable_exceptions, map);
+    }
+
+    fn handle_disable(
+        rest: &str,
+        line_num: usize,
+        active_ranges: &mut HashMap<String, usize>,
+        active_all_range: &mut Option<usize>,
+        enable_exceptions: &mut HashSet<String>,
+        map: &mut SuppressionMap,
+    ) {
+        let rules = parse_rule_ids(rest);
+        if rules.is_empty() {
+            *active_all_range = Some(line_num);
+            enable_exceptions.clear();
+        } else {
+            for rule_id in rules {
+                active_ranges.entry(rule_id).or_insert(line_num);
+            }
+        }
+        Self::propagate_range(line_num, active_ranges, *active_all_range, enable_exceptions, map);
     }
 
     fn propagate_range(


### PR DESCRIPTION
Refactors 20 functions across parser.rs, engine.rs, lib.rs, models.rs, config.rs, suppression.rs, and rules/ to reduce cognitive complexity from 76→≤15 per function.