### PR TITLE
chore: add .scannerwork/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 .worktrees/
 .codex/
 openspec/
+.scannerwork/


### PR DESCRIPTION
Prevents SonarCloud local cache from being tracked.