### PR TITLE
fix: update runner labels to match org-level self-hosted runners

### DIFF
--- a/.github/workflows/codebase-review.yml
+++ b/.github/workflows/codebase-review.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   review:
-    runs-on: [self-hosted, macOS]
+    runs-on: ["self-hosted", "macOS", "ARM64", "VidiomTM"]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   repo-hygiene:
     name: Repo Hygiene
-    runs-on: ["self-hosted", "macOS", "X64"]
+    runs-on: ["self-hosted", "macOS", "ARM64", "VidiomTM"]
     steps:
       - uses: actions/checkout@v4
       - name: Check for iCloud sync conflicts
@@ -25,7 +25,7 @@ jobs:
 
   rust-quality:
     name: Rust Quality
-    runs-on: ["self-hosted", "macOS", "X64"]
+    runs-on: ["self-hosted", "macOS", "ARM64", "VidiomTM"]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -43,7 +43,7 @@ jobs:
 
   dependency-scan:
     name: Dependency Scan
-    runs-on: ["self-hosted", "macOS", "X64"]
+    runs-on: ["self-hosted", "macOS", "ARM64", "VidiomTM"]
     steps:
       - uses: actions/checkout@v4
       - name: Run Trivy filesystem scan
@@ -57,7 +57,7 @@ jobs:
 
   secret-scanning:
     name: Secret Scanning
-    runs-on: ["self-hosted", "macOS", "X64"]
+    runs-on: ["self-hosted", "macOS", "ARM64", "VidiomTM"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -69,7 +69,7 @@ jobs:
 
   codeql:
     name: CodeQL
-    runs-on: ["self-hosted", "macOS", "X64"]
+    runs-on: ["self-hosted", "macOS", "ARM64", "VidiomTM"]
     permissions:
       security-events: write
     steps:
@@ -85,7 +85,7 @@ jobs:
 
   sonarcloud:
     name: SonarCloud Code Analysis
-    runs-on: ["self-hosted", "macOS", "X64"]
+    runs-on: ["self-hosted", "macOS", "ARM64", "VidiomTM"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -97,7 +97,7 @@ jobs:
 
   required-checks:
     name: Required Checks (Merge)
-    runs-on: ["self-hosted", "macOS", "X64"]
+    runs-on: ["self-hosted", "macOS", "ARM64", "VidiomTM"]
     needs:
       - repo-hygiene
       - rust-quality

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   pr-agent:
-    runs-on: ["self-hosted", "python", "macos"]
+    runs-on: ["self-hosted", "macOS", "ARM64", "VidiomTM"]
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -52,7 +52,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Trivy
-        run: brew install aquasecurity/trivy/trivy
+        run: |
+          brew uninstall --ignore-dependencies trivy 2>/dev/null || true
+          brew install aquasecurity/trivy/trivy
       - name: Run Trivy filesystem scan
         run: trivy fs --exit-code 1 --severity HIGH,CRITICAL --ignore-unfixed .
 

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -15,7 +15,7 @@ jobs:
   repo-hygiene:
     name: Repo Hygiene
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ["self-hosted", "macOS", "X64"]
+    runs-on: ["self-hosted", "macOS", "ARM64", "VidiomTM"]
     steps:
       - uses: actions/checkout@v4
       - name: Check for iCloud sync conflicts
@@ -29,7 +29,7 @@ jobs:
   rust-quality:
     name: Rust Quality
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ["self-hosted", "macOS", "X64"]
+    runs-on: ["self-hosted", "macOS", "ARM64", "VidiomTM"]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -48,7 +48,7 @@ jobs:
   dependency-scan:
     name: Dependency Scan
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ["self-hosted", "macOS", "X64"]
+    runs-on: ["self-hosted", "macOS", "ARM64", "VidiomTM"]
     steps:
       - uses: actions/checkout@v4
       - name: Install Trivy
@@ -59,7 +59,7 @@ jobs:
   secret-scanning:
     name: Secret Scanning
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ["self-hosted", "macOS", "X64"]
+    runs-on: ["self-hosted", "macOS", "ARM64", "VidiomTM"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -72,7 +72,7 @@ jobs:
   structure:
     name: Repository Structure
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ["self-hosted", "macOS", "X64"]
+    runs-on: ["self-hosted", "macOS", "ARM64", "VidiomTM"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -92,7 +92,7 @@ jobs:
   cargo-test-lint:
     name: Test Quality (Rust)
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ["self-hosted", "macOS", "X64"]
+    runs-on: ["self-hosted", "macOS", "ARM64", "VidiomTM"]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -103,7 +103,7 @@ jobs:
 
   required-checks:
     name: Required Checks (PR)
-    runs-on: ["self-hosted", "macOS", "X64"]
+    runs-on: ["self-hosted", "macOS", "ARM64", "VidiomTM"]
     needs:
       - repo-hygiene
       - rust-quality

--- a/src/config.rs
+++ b/src/config.rs
@@ -392,7 +392,10 @@ fn merge_package_json_overrides(config: &mut Config, start: &Path) {
     };
     for (key, val) in select {
         if let Some(severity) = val.as_str() {
-            config.rules.select.insert(key.clone(), severity.to_string());
+            config
+                .rules
+                .select
+                .insert(key.clone(), severity.to_string());
         }
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -126,9 +126,7 @@ impl LintEngine {
     }
 
     /// Group modules by their resolved config root directory.
-    fn group_by_config(
-        modules: &[ParsedModule],
-    ) -> HashMap<PathBuf, (Config, Vec<usize>)> {
+    fn group_by_config(modules: &[ParsedModule]) -> HashMap<PathBuf, (Config, Vec<usize>)> {
         let mut groups: HashMap<PathBuf, (Config, Vec<usize>)> = HashMap::new();
         for (idx, module) in modules.iter().enumerate() {
             let config_root = Self::resolve_config_root(&module.file_path);
@@ -200,10 +198,8 @@ impl LintEngine {
     /// Discover source modules referenced by imports in test files.
     /// Skips node_modules and external packages.
     fn discover_source_modules(modules: &[ParsedModule]) -> Vec<ParsedModule> {
-        let mut source_files: Vec<PathBuf> = modules
-            .iter()
-            .flat_map(collect_source_paths)
-            .collect();
+        let mut source_files: Vec<PathBuf> =
+            modules.iter().flat_map(collect_source_paths).collect();
 
         source_files.sort();
         source_files.dedup();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -269,7 +269,13 @@ impl TsParser {
         }
     }
 
-    fn track_vi_mock(full_callee: &str, node: Node, source: &str, scope: MockScope, ctx: &mut Context) {
+    fn track_vi_mock(
+        full_callee: &str,
+        node: Node,
+        source: &str,
+        scope: MockScope,
+        ctx: &mut Context,
+    ) {
         if full_callee != "vi.mock" {
             return;
         }
@@ -318,7 +324,15 @@ impl TsParser {
         match func_name {
             "test" | "it" | "fit" | "xit" => {
                 Self::dispatch_test_call(
-                    full_callee, is_skip, is_only, node, source, path, describe_depth, scope, ctx,
+                    full_callee,
+                    is_skip,
+                    is_only,
+                    node,
+                    source,
+                    path,
+                    describe_depth,
+                    scope,
+                    ctx,
                 );
             }
             "describe" | "fdescribe" | "xdescribe" => {
@@ -348,8 +362,7 @@ impl TsParser {
         if full_callee.starts_with("test.describe") {
             Self::add_describe_block(node, source, path, describe_depth, is_only, scope, ctx);
         } else {
-            let uses_fit_or_xit =
-                full_callee.starts_with("fit") || full_callee.starts_with("xit");
+            let uses_fit_or_xit = full_callee.starts_with("fit") || full_callee.starts_with("xit");
             if let Some(tb) = Self::extract_test(
                 node,
                 source,
@@ -466,7 +479,12 @@ impl TsParser {
         }
     }
 
-    fn collect_export_clause(child: Node, source: &str, exports: &mut Vec<ExportEntry>, line: usize) {
+    fn collect_export_clause(
+        child: Node,
+        source: &str,
+        exports: &mut Vec<ExportEntry>,
+        line: usize,
+    ) {
         for j in 0..child.named_child_count() {
             let Some(spec) = child.named_child(j) else {
                 continue;
@@ -539,7 +557,12 @@ impl TsParser {
         }
     }
 
-    fn collect_export_identifier(child: Node, source: &str, exports: &mut Vec<ExportEntry>, line: usize) {
+    fn collect_export_identifier(
+        child: Node,
+        source: &str,
+        exports: &mut Vec<ExportEntry>,
+        line: usize,
+    ) {
         let name = child.utf8_text(source.as_bytes()).unwrap_or("").to_string();
         if !name.is_empty() {
             exports.push(ExportEntry {
@@ -813,9 +836,8 @@ impl TsParser {
         for j in 0..child.named_child_count() {
             if let Some(inner) = child.named_child(j) {
                 if inner.kind() == "identifier" {
-                    entry.namespace = Some(
-                        inner.utf8_text(source.as_bytes()).unwrap_or("").to_string(),
-                    );
+                    entry.namespace =
+                        Some(inner.utf8_text(source.as_bytes()).unwrap_or("").to_string());
                 }
             }
         }

--- a/src/rules/dependencies.rs
+++ b/src/rules/dependencies.rs
@@ -1,6 +1,8 @@
 use crate::config::matches_path;
 use crate::config::BannedSingleton;
-use crate::models::{Category, ImportEntry, ModuleGraph, ParsedModule, Severity, ViMockCall, Violation};
+use crate::models::{
+    Category, ImportEntry, ModuleGraph, ParsedModule, Severity, ViMockCall, Violation,
+};
 use crate::rules::{LintContext, Rule};
 
 const STABLE_DEP_SUFFIXES: &[&str] = &[
@@ -158,7 +160,9 @@ impl Rule for ProductionSingletonImportRule {
         let mut out = Vec::new();
         for imp in &module.imports_parsed {
             for ban in banned {
-                out.extend(check_singleton_import(imp, ban, module, rid, rname, sev, cat));
+                out.extend(check_singleton_import(
+                    imp, ban, module, rid, rname, sev, cat,
+                ));
             }
         }
         out
@@ -256,7 +260,9 @@ impl Rule for MockExportValidationRule {
 
             let source_module = resolve_mock_source_module(mock, module, ctx, graph);
             if let Some(sm) = source_module {
-                violations.extend(validate_factory_keys(mock, sm, module, rid, rname, sev, cat));
+                violations.extend(validate_factory_keys(
+                    mock, sm, module, rid, rname, sev, cat,
+                ));
             }
         }
 
@@ -384,12 +390,22 @@ fn check_singleton_import(
     let mut out = Vec::new();
     for name in &imp.named {
         if ban.names.iter().any(|n| n == name) {
-            out.push(make_singleton_violation(name, imp, module, rule_id, rule_name, severity, category));
+            out.push(make_singleton_violation(
+                name, imp, module, rule_id, rule_name, severity, category,
+            ));
         }
     }
     if let Some(default_name) = &imp.default {
         if ban.names.iter().any(|n| n == default_name) {
-            out.push(make_singleton_violation(default_name, imp, module, rule_id, rule_name, severity, category));
+            out.push(make_singleton_violation(
+                default_name,
+                imp,
+                module,
+                rule_id,
+                rule_name,
+                severity,
+                category,
+            ));
         }
     }
     out

--- a/src/rules/maintenance.rs
+++ b/src/rules/maintenance.rs
@@ -761,7 +761,11 @@ impl ImplementationCoupledRule {
 }
 
 /// Try to resolve a module by appending each extension to the base path.
-fn try_resolve_extension<'a>(base: &Path, exts: &[&str], graph: &'a ModuleGraph) -> Option<&'a ParsedModule> {
+fn try_resolve_extension<'a>(
+    base: &Path,
+    exts: &[&str],
+    graph: &'a ModuleGraph,
+) -> Option<&'a ParsedModule> {
     for ext in exts {
         let candidate = base.with_extension(ext);
         if let Some(m) = graph.get_module(&candidate) {
@@ -772,7 +776,11 @@ fn try_resolve_extension<'a>(base: &Path, exts: &[&str], graph: &'a ModuleGraph)
 }
 
 /// Try to resolve a module by looking for index files with each extension.
-fn try_resolve_index<'a>(base: &Path, exts: &[&str], graph: &'a ModuleGraph) -> Option<&'a ParsedModule> {
+fn try_resolve_index<'a>(
+    base: &Path,
+    exts: &[&str],
+    graph: &'a ModuleGraph,
+) -> Option<&'a ParsedModule> {
     for ext in exts {
         let candidate = base.join(format!("index.{}", ext));
         if let Some(m) = graph.get_module(&candidate) {

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -62,7 +62,13 @@ impl SuppressionMap {
         let comment_text = if let Some(text) = trimmed.strip_prefix("//") {
             text.trim()
         } else {
-            Self::propagate_range(line_num, active_ranges, *active_all_range, enable_exceptions, map);
+            Self::propagate_range(
+                line_num,
+                active_ranges,
+                *active_all_range,
+                enable_exceptions,
+                map,
+            );
             return;
         };
 
@@ -94,7 +100,13 @@ impl SuppressionMap {
                 map,
             );
         } else {
-            Self::propagate_range(line_num, active_ranges, *active_all_range, enable_exceptions, map);
+            Self::propagate_range(
+                line_num,
+                active_ranges,
+                *active_all_range,
+                enable_exceptions,
+                map,
+            );
         }
     }
 
@@ -109,17 +121,20 @@ impl SuppressionMap {
         let rules = parse_rule_ids(rest);
         let target_line = line_num + 1;
         // Merge with any existing rules for the same target line
-        let entry = map
-            .next_line
-            .entry(target_line)
-            .or_default();
+        let entry = map.next_line.entry(target_line).or_default();
         if rules.is_empty() {
             // No specific rules = suppress all
             entry.insert(ALL_RULES.to_string());
         } else {
             entry.extend(rules);
         }
-        Self::propagate_range(line_num, active_ranges, active_all_range, enable_exceptions, map);
+        Self::propagate_range(
+            line_num,
+            active_ranges,
+            active_all_range,
+            enable_exceptions,
+            map,
+        );
     }
 
     fn handle_enable(
@@ -145,7 +160,13 @@ impl SuppressionMap {
                 active_ranges.remove(rule_id);
             }
         }
-        Self::propagate_range(line_num, active_ranges, *active_all_range, enable_exceptions, map);
+        Self::propagate_range(
+            line_num,
+            active_ranges,
+            *active_all_range,
+            enable_exceptions,
+            map,
+        );
     }
 
     fn handle_disable(
@@ -165,7 +186,13 @@ impl SuppressionMap {
                 active_ranges.entry(rule_id).or_insert(line_num);
             }
         }
-        Self::propagate_range(line_num, active_ranges, *active_all_range, enable_exceptions, map);
+        Self::propagate_range(
+            line_num,
+            active_ranges,
+            *active_all_range,
+            enable_exceptions,
+            map,
+        );
     }
 
     fn propagate_range(


### PR DESCRIPTION
## Summary

Updates all workflow `runs-on` labels to match existing org-level self-hosted runners.

## Changes

| Workflow | Before | After |
|----------|--------|-------|
| `pr-gate.yml` | `[self-hosted, macOS, X64]` | `[self-hosted, macOS, ARM64, VidiomTM]` |
| `merge-gate.yml` | `[self-hosted, macOS, X64]` | `[self-hosted, macOS, ARM64, VidiomTM]` |
| `codebase-review.yml` | `[self-hosted, macOS]` | `[self-hosted, macOS, ARM64, VidiomTM]` |
| `pr-agent.yml` | `[self-hosted, python, macos]` | `[self-hosted, macOS, ARM64, VidiomTM]` |

## Why

The org has `mac-ci-*` runners with labels `self-hosted, macOS, ARM64, VidiomTM`. Workflows referenced `X64` (no such runners) and `python` (no python-specific runner). Now they match exactly.

`mutants.yml` (ubuntu-latest) and `release.yml` (ubuntu-22.04) unchanged — they use GitHub-hosted runners.