### PR TITLE
chore: v1.0.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vitest-linter"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 repository = "https://github.com/VidiomTM/vitest-linter"
 


### PR DESCRIPTION
Bumps version from 0.1.0 to 1.0.0. Tag v1.0.0 pushed.