### PR TITLE
fix(docs): correct rule count, add Playwright category, fix descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A fast, zero-config test-smell linter for TypeScript/JavaScript Vitest test suit
 
 ## Features
 
-- **8 must-have rules** active by default for v1.0 (65 total behind `--unstable-rules`)
+- **8 must-have rules** active by default for v1.0 (66 total behind `--unstable-rules`)
 - Optional `.vitest-linter.toml` for project-specific banlists (DI rules)
 - Recursive file discovery via [walkdir](https://docs.rs/walkdir)
 - Tree-sitter-powered AST analysis (TypeScript **and** TSX/JSX)
@@ -52,7 +52,8 @@ vitest-linter --unstable-rules
 
 > **8 must-have rules** active by default for v1.0. These catch the most
 > real-world pain (high signal, low false-positive). Pass `--unstable-rules`
-> to access the full set of 65 rules across 5 categories.
+> to access the full set of 66 rules across 6 categories (organized into 10
+> rule groups by ID prefix).
 
 ### v1.0 Rules (active by default)
 
@@ -64,7 +65,7 @@ real codebases with minimal noise.
 | VITEST-MNT-007 | FocusedTestRule | Error | `it.only` / `test.only` / `describe.only` left in source |
 | VITEST-MNT-005 | EmptyTestRule | Info | `it.skip` / `test.todo` left in source |
 | VITEST-NO-003 | NoCommentedOutTestsRule | Maintenance | Commented-out `it(` / `test(` / `describe(` lines |
-| VITEST-MNT-006 | MissingAwaitAssertionRule | Error | `.resolves` or `.rejects` assertion not preceded by `await` |
+| VITEST-MNT-006 | MissingAwaitAssertionRule | Warning | `.resolves` or `.rejects` assertion not preceded by `await` |
 | VITEST-FLK-001 | TimeoutRule | Warning | `setTimeout`/`setInterval` used inside a test without fake timers |
 | VITEST-MNT-004 | TryCatchRule | Warning | `try/catch` inside a test — prefer `expect().toThrow()` |
 | VITEST-MNT-003 | ConditionalLogicRule | Warning | `if` or `switch` statement inside a test body |
@@ -94,9 +95,12 @@ are still being validated against real-world repos and may produce false positiv
 | VITEST-MNT-003 | ConditionalLogicRule | Warning | `if` or `switch` statement inside a test body |
 | VITEST-MNT-004 | TryCatchRule | Warning | `try/catch` inside a test — prefer `expect().toThrow()` |
 | VITEST-MNT-005 | EmptyTestRule | Info | `it.skip` / `test.todo` left in source |
-| VITEST-MNT-006 | MissingAwaitAssertionRule | Error | `.resolves` or `.rejects` assertion not preceded by `await` |
+| VITEST-MNT-006 | MissingAwaitAssertionRule | Warning | `.resolves` or `.rejects` assertion not preceded by `await` |
 | VITEST-MNT-007 | FocusedTestRule | Error | `it.only` / `test.only` / `describe.only` left in source |
 | VITEST-MNT-008 | MissingMockCleanupRule | Warning | `vi.mock()` without `afterEach` cleanup (`vi.restoreAllMocks()` / `vi.clearAllMocks()`) |
+| VITEST-MNT-009 | WeakAssertionRule | Warning | All assertions in a test are weak (`toBeDefined()`, `toBeTruthy()`, `not.toThrow()`) — verify actual behavior |
+| VITEST-MNT-010 | ImplementationCoupledRule | Warning | Test file is tightly coupled to a single module's implementation — test count ≈ export count with >80% name match |
+| VITEST-MNT-011 | TestIdNegativePresenceRule | Warning | Uses `getByTestId` but has no negative-presence assertion — missing coverage for element absence |
 
 ### Structure (VITEST-STR-*)
 
@@ -108,23 +112,25 @@ are still being validated against real-world repos and may produce false positiv
 ### Dependencies (VITEST-DEP-*)
 
 Catch test-isolation bugs that arise from module-level mocking of singleton
-infrastructure. Active only when `.vitest-linter.toml` configures a banlist.
+infrastructure. DEP-001 also fires on stable dependencies (pure functions,
+data models) detected via heuristics. DEP-002 requires a configured banlist.
 
 | Rule ID | Name | Severity | Description |
 |---------|------|----------|-------------|
-| VITEST-DEP-001 | BannedModuleMockRule | Error | `vi.mock(<path>)` at module scope where path matches a configured banlist (e.g. shared `db`/`eventBus`/`container`). Such mocks leak across test files via the module cache and silently corrupt downstream tests. Refactor the target service to accept dependencies via constructor (DI). |
+| VITEST-DEP-001 | BannedModuleMockRule | Error | `vi.mock(<path>)` at module scope where path matches a configured banlist (e.g. shared `db`/`eventBus`/`container`) or is detected as a stable dependency (pure functions, data models, utils). Mocking stable deps indicates a DI problem. Refactor the target service to accept dependencies via constructor (DI). |
 | VITEST-DEP-002 | ProductionSingletonImportRule | Error | Unit test imports a configured production singleton. Importing the singleton triggers its constructor side effects (event-handler registration, DB connections) on the production wiring. Construct a fresh instance with fakes; production singletons belong in `*.integration.test.ts` only. |
-| VITEST-DEP-003 | ResetEscapeHatchRule | Warning | `vi.resetModules()` / `vi.restoreAllMocks()` / `vi.unmock()` inside `beforeEach`/`beforeAll`/`afterEach`/`afterAll`. These mask underlying coupling between test files instead of fixing it. |
+| VITEST-DEP-003 | ResetEscapeHatchRule | Warning | `vi.resetModules()` / `vi.restoreAllMocks()` / `vi.unmock()` / `vi.doUnmock()` inside `beforeEach`/`beforeAll`/`afterEach`/`afterAll`. These mask underlying coupling between test files instead of fixing it. |
+| VITEST-DEP-004 | MockExportValidationRule | Warning | `vi.mock()` factory returns a key that is not exported by the source module |
 
 ### Validation (VITEST-VAL-*)
 
 | Rule ID | Name | Severity | Description |
 |---------|------|----------|-------------|
 | VITEST-VAL-001 | ValidExpectRule | Error | `expect()` call missing `.toBe()` or similar assertion — promise silently swallowed |
-| VITEST-VAL-002 | ValidExpectInPromiseRule | Error | `expect()` inside a `.then()` / `catch()` without `return` — assertion may never run |
-| VITEST-VAL-003 | ValidDescribeCallbackRule | Error | `describe()` with no callback or a non-function callback |
-| VITEST-VAL-004 | ValidTitleRule | Warning | Test/describe title is empty, a duplicate, or not a string literal |
-| VITEST-VAL-005 | NoUnneededAsyncExpectFunctionRule | Warning | Using `expect(await ...)` or `.resolves` with an already-sync matcher |
+| VITEST-VAL-002 | ValidExpectInPromiseRule | Error | `return expect(...)` instead of `await expect(...)` — assertion may fail silently |
+| VITEST-VAL-003 | ValidDescribeCallbackRule | Error | `describe()` with an `async` callback — must be synchronous |
+| VITEST-VAL-004 | ValidTitleRule | Warning | Test/describe title is empty or a template literal — prefer static string titles |
+| VITEST-VAL-005 | NoUnneededAsyncExpectFunctionRule | Warning | `expect(async () => {...})` wrapping async function unnecessarily — use `.resolves` / `.rejects` instead |
 
 ### No-* (VITEST-NO-*)
 
@@ -133,7 +139,7 @@ infrastructure. Active only when `.vitest-linter.toml` configures a banlist.
 | VITEST-NO-001 | NoStandaloneExpectRule | Error | `expect()` call outside any `it`/`test` body |
 | VITEST-NO-002 | NoIdenticalTitleRule | Error | Two `it`/`describe` blocks in the same scope share the same title |
 | VITEST-NO-003 | NoCommentedOutTestsRule | Maintenance | Commented-out `it(` / `test(` / `describe(` lines |
-| VITEST-NO-005 | NoTestPrefixesRule | Warning | `test.skip` / `test.only` used instead of `it.skip` / `it.only` |
+| VITEST-NO-005 | NoTestPrefixesRule | Warning | `fit()` / `xit()` used — use `test.skip()` / `test.only()` instead |
 | VITEST-NO-006 | NoDuplicateHooksRule | Warning | Multiple `beforeEach` / `afterEach` / etc. in the same `describe` |
 | VITEST-NO-007 | NoImportNodeTestRule | Error | `import ... from 'node:test'` in a Vitest project |
 | VITEST-NO-008 | NoInterpolationInSnapshotsRule | Warning | Template literal with `${}` inside `toMatchSnapshot()` |
@@ -171,6 +177,27 @@ infrastructure. Active only when `.vitest-linter.toml` configures a banlist.
 | VITEST-CON-001 | ConsistentTestItRule | Maintenance | Mix of `test()` and `it()` in the same file — pick one |
 | VITEST-CON-003 | ConsistentVitestViRule | Dependencies | Mix of `vi` named import and `vitest` namespace import |
 | VITEST-CON-004 | HoistedApisOnTopRule | Structure | `vi.mock()` / `vi.hoisted()` calls should precede all `test`/`it`/`describe` blocks |
+
+### Playwright (VITEST-PW-*)
+
+Best-practice rules for Playwright E2E test files. These rules only fire when
+the test runtime is detected as Playwright (via `@playwright/test` imports).
+
+| Rule ID | Name | Severity | Description |
+|---------|------|----------|-------------|
+| VITEST-PW-001 | PwWaitForTimeoutRule | Warning | `waitForTimeout` causes flaky waits — prefer auto-retry assertions |
+| VITEST-PW-002 | PwCssIdSelectorRule | Warning | CSS ID selector used — IDs may not be stable across app updates |
+| VITEST-PW-003 | PwXPathSelectorRule | Warning | XPath selectors are brittle — prefer role/text/accessible-name locators |
+| VITEST-PW-004 | PwLocatorNthRule | Warning | `.nth()` positional locator is fragile — DOM order may change |
+| VITEST-PW-005 | PwPageDollarRule | Warning | `page.$` / `page.$$` returns raw ElementHandle — prefer locator API |
+| VITEST-PW-006 | PwEvaluateInnerTextRule | Warning | `page.evaluate` with `innerText` — prefer ARIA text assertions or `getByText` |
+| VITEST-PW-007 | PwTextAssertionOverRoleRule | Info | `getByText` used — prefer `getByRole` for interactive elements |
+| VITEST-PW-008 | PwTestIdOverSemanticRoleRule | Info | Only `getByTestId` locators — prefer semantic role/text locators |
+| VITEST-PW-009 | PwDuplicateSpecFileRule | Warning | Spec file name overlaps with another Playwright file — consolidate |
+| VITEST-PW-010 | PwArbitrarySleepRule | Warning | Arbitrary `setTimeout` in Promise — prefer Playwright auto-waiting assertions |
+| VITEST-PW-011 | PwHardCssClassChainRule | Warning | Hard CSS class selector chain — fragile to DOM structure changes |
+| VITEST-PW-012 | PwMissingWebFirstAssertionRule | Warning | Playwright calls without accessor locators — use web-first assertions |
+| VITEST-PW-100 | PwMissingAxeScanRule | Info | No axe accessibility scan — consider `@axe-core/playwright` |
 
 ## Configuration (`.vitest-linter.toml`)
 
@@ -237,8 +264,9 @@ test('has conditionals', () => {
 // vitest-linter-enable VITEST-MNT-003
 ```
 
-If no config file exists, DEP-001 and DEP-002 are inactive (no banlist → no
-violations); DEP-003 still runs with its built-in defaults.
+If no config file exists, DEP-002 is inactive (no banlist → no
+violations); DEP-001 still fires on stable dependencies (pure functions, data
+models) detected via heuristics; DEP-003 still runs with its built-in defaults.
 
 ## Supported File Extensions
 

--- a/docs/architecture/ADR-001-project-architecture.md
+++ b/docs/architecture/ADR-001-project-architecture.md
@@ -41,7 +41,7 @@ src/
     mod.rs         # Rule trait, v1_0_rules(), all_rules() registration
     flakiness.rs   # VITEST-FLK-* rules
     maintenance.rs # VITEST-MNT-* rules
-    no_rules.rs    # VITEST-NO-* rules
+    no_category.rs # VITEST-NO-* rules
     prefer.rs      # VITEST-PREF-* rules
     require.rs     # VITEST-REQ-* rules
     consistency.rs # VITEST-CON-* rules

--- a/docs/architecture/ADR-002-toolchain.md
+++ b/docs/architecture/ADR-002-toolchain.md
@@ -34,7 +34,7 @@ The project needs a consistent Rust toolchain for building, linting, formatting,
 | `cargo-llvm-cov` | nightly with `llvm-tools-preview` | CLI args | Branch coverage (`--fail-under-lines 90`) |
 | `cargo-audit` | stable | `Cargo.lock` | Dependency vulnerability scanning |
 | `cargo-mutants` | stable | `.cargo/mutants.toml` | Mutation testing (score ≥75% gate) |
-| `cargo-dist` | 0.28.0 | `Cargo.toml` (workspace metadata) | Binary release + npm publishing |
+| `cargo-dist` | 0.31.0 | `Cargo.toml` (workspace metadata) | Binary release + npm publishing |
 | `cargo-deny` | stable (planned) | `deny.toml` (planned) | License + duplicate dep checking |
 | `structurelint` | Go 1.24 | `.structurelint.yml` | Repo structure linting |
 

--- a/docs/architecture/ADR-005-lint-rule-architecture.md
+++ b/docs/architecture/ADR-005-lint-rule-architecture.md
@@ -22,7 +22,7 @@ checksum: b214362d6987fe751115cbc3df4fc0ce295f5d5de5fab18f38abed0515be943e
 
 ## Context
 
-vitest-linter must support 65 lint rules (8 stable + 57 unstable) across 7 categories. Rules need to analyze tree-sitter AST data, respect config overrides, support inline suppression, and gate by test runtime. The architecture must make adding new rules mechanical.
+vitest-linter must support 66 lint rules (8 stable + 58 unstable) across 6 categories. Rules need to analyze tree-sitter AST data, respect config overrides, support inline suppression, and gate by test runtime. The architecture must make adding new rules mechanical.
 
 ## Decision
 
@@ -48,26 +48,26 @@ Two registration functions in `src/rules/mod.rs`:
 | Function | Purpose | Rules |
 |----------|---------|-------|
 | `v1_0_rules()` | Active by default (no flag) | 8 community-hit rules |
-| `all_rules()` | Behind `--unstable-rules` | All 65 rules |
+| `all_rules()` | Behind `--unstable-rules` | All 66 rules |
 
 The engine checks `config.rules.is_disabled(rule_id)` before calling `check()`.
 
 ### Categories
 
+The `Category` enum has 6 variants. Rules are assigned categories by what they
+detect, not by their ID prefix — e.g. `VITEST-NO-001` has `Structure` category,
+not a `No-*` category.
+
 ```
-Flakiness (5)    - VITEST-FLK-*    → Non-deterministic test behavior
-Maintenance (18) - VITEST-MNT-*   → Code quality and test hygiene
-Structure (9)    - VITEST-STR-*   → Test organization and nesting
-Dependencies (7) - VITEST-DEP-*    → Mock and import isolation
-Validation (5)   - VITEST-VAL-*   → Correct test API usage
-Playwright (13)  - VITEST-PW-*    → Playwright E2E best practices
-No-* (10)        - VITEST-NO-*    → Banned patterns
-Prefer-* (10)    - VITEST-PREF-*  → Idiomatic matchers
-Require-* (3)    - VITEST-REQ-*   → Required patterns
-Consistency (3)  - VITEST-CON-*   → Consistent style
+Flakiness (5)     - Non-deterministic test behavior (VITEST-FLK-*)
+Maintenance (18)  - Code quality and test hygiene (VITEST-MNT-* + several NO/PREF/CON rules)
+Structure (9)     - Test organization and nesting (VITEST-STR-* + several NO/PREF/REQ/CON rules)
+Dependencies (7)  - Mock and import isolation (VITEST-DEP-* + NO-007, PREF-005, CON-003)
+Validation (14)   - Correct test API usage (VITEST-VAL-* + several NO/PREF/REQ rules)
+Playwright (13)   - Playwright E2E best practices (VITEST-PW-*)
 ```
 
-Total: 66 (8 stable + 58 unstable). Duplicate: 66 rules in `all_rules()` test.
+Total: 66 (8 stable + 58 unstable). 66 rules in `all_rules()` test.
 
 ### AST-Based Analysis
 

--- a/docs/technical-due-diligence.md
+++ b/docs/technical-due-diligence.md
@@ -23,19 +23,19 @@ checksum: a315273f9c4c04e2ea67945e0b823615652c6e2357289b582b18fabf1602bd4d
 
 ## Executive Summary
 
-vitest-linter v0.1.0 is a well-architected Rust CLI using tree-sitter for AST-level test smell detection across 65 rules (8 stable, 57 unstable). Multi-channel distribution (cargo-dist for 5 platforms, npm, VSCode extension, GitHub Action, ESLint plugin, sigstore signing) is excellent. The 8:57 stable-to-unstable ratio is the main maturity signal -- unstable rules may change behavior between releases. No coverage threshold in CI and no cargo audit. Recommendation: add dependency scanning, define rule lifecycle policy, and enforce coverage.
+vitest-linter v1.0.0 is a well-architected Rust CLI using tree-sitter for AST-level test smell detection across 66 rules (8 stable, 58 unstable). Multi-channel distribution (cargo-dist for 5 platforms, npm, VSCode extension, GitHub Action, ESLint plugin, sigstore signing) is excellent. The 8:58 stable-to-unstable ratio is the main maturity signal -- unstable rules may change behavior between releases. No coverage threshold in CI and no cargo audit. Recommendation: add dependency scanning, define rule lifecycle policy, and enforce coverage.
 
 ## Scope
 
-Assessed: 65 rules across 9 categories (Flakiness, Maintenance, Consistency, Dependencies, Validation, No-*, Prefer-*, Require-*, Playwright), tree-sitter AST engine, CLI + npm + VSCode + GitHub Action + ESLint plugin distribution channels, cargo-dist build with sigstore, criterion benchmarks, cargo-mutants mutation testing, SonarCloud, 5 ADRs. Excluded: IDE integration beyond VSCode, Docker distribution, fuzz testing.
+Assessed: 66 rules across 6 categories (Flakiness, Maintenance, Structure, Dependencies, Validation, Playwright), tree-sitter AST engine, CLI + npm + VSCode + GitHub Action + ESLint plugin distribution channels, cargo-dist build with sigstore, criterion benchmarks, cargo-mutants mutation testing, SonarCloud, 5 ADRs. Excluded: IDE integration beyond VSCode, Docker distribution, fuzz testing.
 
 ## Architecture
 
-Single Rust crate with modular rule engine -- 9 rule categories as separate modules registered via mod.rs. tree-sitter produces CST/AST for pattern matching. Comment-based suppression system (`// vitest-linter-ignore`) with mutation testing evidence. Multi-format output: terminal (colored), JSON, SARIF. Zero-config defaults with optional `vitest-linter.toml`. Multi-channel distribution via cargo-dist covering 5 target triples (macOS aarch64/x86_64, Linux aarch64/x86_64, Windows x86_64). npm and VSCode wrapper packages download the prebuilt binary.
+Single Rust crate with modular rule engine -- rules organized by ID prefix across 9 source modules, with 6 `Category` enum variants for classification. tree-sitter produces CST/AST for pattern matching. Comment-based suppression system (`// vitest-linter-disable-next-line` / `// vitest-linter-disable` / `// vitest-linter-enable`) with mutation testing evidence. Multi-format output: terminal (colored), JSON, SARIF. Zero-config defaults with optional `vitest-linter.toml`. Multi-channel distribution via cargo-dist covering 5 target triples (macOS aarch64/x86_64, Linux aarch64/x86_64, Windows x86_64). npm and VSCode wrapper packages download the prebuilt binary.
 
 ## Tech Stack
 
-Rust 2021 edition, tree-sitter 0.24 + tree-sitter-typescript 0.23, clap 4 (derive), serde + serde_json, anyhow, colored, walkdir, toml 0.8, globset, rayon. Build: cargo-dist 0.28, sigstore signing, thin LTO. Benchmarks: criterion with HTML reports. Mutation: cargo-mutants. CI: format + clippy (nightly, pedantic+nursery) + test + coverage. Quality: SonarCloud.
+Rust 2021 edition, tree-sitter 0.24 + tree-sitter-typescript 0.23, clap 4 (derive), serde + serde_json, anyhow, colored, walkdir, toml 0.8, globset, rayon. Build: cargo-dist 0.31, sigstore signing, thin LTO. Benchmarks: criterion with HTML reports. Mutation: cargo-mutants. CI: format + clippy (nightly, pedantic+nursery) + test + coverage. Quality: SonarCloud.
 
 ## Code Quality
 
@@ -61,7 +61,7 @@ criterion benchmarks for large corpus linting. tree-sitter parsing scales linear
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|------------|
-| 57 unstable rules with no graduation criteria | Medium | Medium | Document rule lifecycle policy |
+| 58 unstable rules with no graduation criteria | Medium | Medium | Document rule lifecycle policy |
 | No coverage threshold in CI | Medium | Medium | Add cargo-llvm-cov gate with minimum threshold |
 | No cargo audit in CI | Medium | Medium | Add cargo audit step |
 | npm postinstall may fail in restricted envs | Low | Medium | Document alternative install methods |

--- a/eslint-plugin-vitest-linter/README.md
+++ b/eslint-plugin-vitest-linter/README.md
@@ -56,7 +56,7 @@ Override any rule severity in your ESLint config:
 
 ## Rules
 
-The plugin exposes one ESLint rule per vitest-linter rule (65 total). Each rule maps to the corresponding `VITEST-*` diagnostic from the standalone CLI.
+The plugin exposes one ESLint rule per vitest-linter rule (66 total). Each rule maps to the corresponding `VITEST-*` diagnostic from the standalone CLI.
 
 | ESLint rule | Linter ID |
 |---|---|
@@ -77,6 +77,7 @@ The plugin exposes one ESLint rule per vitest-linter rule (65 total). Each rule 
 | `missing-mock-cleanup` | VITEST-MNT-008 |
 | `weak-assertion` | VITEST-MNT-009 |
 | `implementation-coupled` | VITEST-MNT-010 |
+| `test-id-negative-presence` | VITEST-MNT-011 |
 | `banned-module-mock` | VITEST-DEP-001 |
 | `production-singleton-import` | VITEST-DEP-002 |
 | `reset-escape-hatch` | VITEST-DEP-003 |
@@ -113,15 +114,15 @@ The plugin exposes one ESLint rule per vitest-linter rule (65 total). Each rule 
 | `consistent-vitest-vi` | VITEST-CON-003 |
 | `hoisted-apis-on-top` | VITEST-CON-004 |
 | `pw-wait-for-timeout` | VITEST-PW-001 |
-| `pw-evaluate-inner-text` | VITEST-PW-002 |
-| `pw-css-id-selector` | VITEST-PW-003 |
-| `pw-xpath-selector` | VITEST-PW-004 |
-| `pw-locator-nth` | VITEST-PW-005 |
-| `pw-arbitrary-sleep` | VITEST-PW-006 |
+| `pw-css-id-selector` | VITEST-PW-002 |
+| `pw-xpath-selector` | VITEST-PW-003 |
+| `pw-locator-nth` | VITEST-PW-004 |
+| `pw-page-dollar` | VITEST-PW-005 |
+| `pw-evaluate-inner-text` | VITEST-PW-006 |
+| `pw-arbitrary-sleep` | VITEST-PW-010 |
 | `pw-text-assertion-over-role` | VITEST-PW-007 |
 | `pw-test-id-over-semantic-role` | VITEST-PW-008 |
 | `pw-duplicate-spec-file` | VITEST-PW-009 |
-| `pw-page-dollar` | VITEST-PW-010 |
 | `pw-hard-css-class-chain` | VITEST-PW-011 |
 | `pw-missing-web-first-assertion` | VITEST-PW-012 |
 | `pw-missing-axe-scan` | VITEST-PW-100 |

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -8,7 +8,7 @@ Zero-config test-smell diagnostics for Vitest projects, directly in VS Code.
 
 - Activates automatically when editing test files (`.test.ts`, `.spec.ts`, `.test.js`, etc.)
 - Runs [vitest-linter](https://github.com/Jonathangadeaharder/vitest-linter) on save (or on type) and shows diagnostics in the Problems panel
-- Supports 65+ lint rules across flakiness, maintenance, structure, dependencies, validation, and Playwright categories
+- Supports 66 lint rules across flakiness, maintenance, structure, dependencies, validation, and Playwright categories
 - Configurable rule severity overrides, include/exclude globs, and run trigger
 
 ## Prerequisites


### PR DESCRIPTION
## Documentation Audit Fixes

Corrects inaccuracies found during documentation audit against actual source code.

### Changes

- **Rule count**: 65→66 throughout (README, ADR-005, technical-due-diligence)
- **Playwright category**: Add entire category (13 rules) missing from README
- **Rule descriptions**: Fix 6 descriptions to match actual code behavior
- **Missing rules**: Add VITEST-MNT-009/010/011 and VITEST-DEP-004 to README
- **eslint-plugin README**: Fix Playwright rule mappings
- **ADR-001**: Fix filename
- **ADR-002**: Fix cargo-dist version
- **ADR-005**: Fix category count
- **Suppression comments**: Fix syntax
- **Technical due diligence**: Fix version and category count

### Files changed (7)
`README.md`, `docs/architecture/ADR-001`, `ADR-002`, `ADR-005`, `docs/technical-due-diligence.md`, `eslint-plugin-vitest-linter/README.md`, `vscode/README.md`