### PR TITLE
chore(sonar): rebind to vidiomtm org

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=Jonathangadeaharder_vitest-linter
-sonar.organization=jonathangadeaharder
+sonar.projectKey=VidiomTM_vitest-linter
+sonar.organization=vidiomtm
 sonar.sources=src
 sonar.tests=tests
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Repo moved to the VidiomTM GitHub org; `sonar-project.properties` still pointed at the personal SonarCloud org/project (`Jonathangadeaharder_*`), causing 'Could not find the pullrequest' failures. Repoint to the vidiomtm-org project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SonarQube project configuration with new identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->